### PR TITLE
fixed self.noise capitalization

### DIFF
--- a/rlpy/Domains/MountainCar.py
+++ b/rlpy/Domains/MountainCar.py
@@ -69,7 +69,7 @@ class MountainCar(Domain):
         """
         self.statespace_limits = np.array(
             [[self.XMIN, self.XMAX], [self.XDOTMIN, self.XDOTMAX]])
-        self.Noise = noise
+        self.noise = noise
         # Visual stuff:
         self.xTicks = np.linspace(0, self.X_discretization - 1, 5)
         self.xTicksLabels = np.linspace(self.XMIN, self.XMAX, 5)

--- a/rlpy/Domains/RCCar.py
+++ b/rlpy/Domains/RCCar.py
@@ -84,7 +84,7 @@ class RCCar(Domain):
                  self.SPEEDMAX],
                 [self.HEADINGMIN,
                  self.HEADINGMAX]])
-        self.Noise = noise
+        self.noise = noise
         super(RCCar, self).__init__()
 
     def step(self, a):


### PR DESCRIPTION
MountainCar and RCCar both initialize their noise parameter in `__init__`, but noise is currently assigned to `self.Noise` instead of the actual value of `self.noise`. As a result, noise was never changing.

I think I might be able to remove noise from the RC Car domain, but I haven't used the RC Car domain so I am just going to fix the reference.

[build](https://travis-ci.org/MDPvis/rlpy/builds/88229361) 