### PR TITLE
Bad position argument in RBF init()

### DIFF
--- a/rlpy/Representations/RBF.py
+++ b/rlpy/Representations/RBF.py
@@ -82,7 +82,7 @@ class RBF(Representation):
         self.state_dimensions = state_dimensions
         self.normalize = normalize
 
-        super(RBF, self).__init__(domain)
+        super(RBF, self).__init__(domain, seed=seed)
 
         self.init_randomization()
 

--- a/rlpy/Representations/RBF.py
+++ b/rlpy/Representations/RBF.py
@@ -82,7 +82,7 @@ class RBF(Representation):
         self.state_dimensions = state_dimensions
         self.normalize = normalize
 
-        super(RBF, self).__init__(domain, seed)
+        super(RBF, self).__init__(domain)
 
         self.init_randomization()
 


### PR DESCRIPTION
Representation.py has a constructor signature:
(self, domain, discretization=20, seed=1)
RBF.py calls with positional arguments (domain, seed); as a result, discretization takes on the value of your experiment seed.