### PR TITLE
Changes use of fmin to std::min because fmin is dependant on C++11

### DIFF
--- a/rlpy/Representations/c_kernels.cc
+++ b/rlpy/Representations/c_kernels.cc
@@ -34,7 +34,7 @@ double linf_triangle_kernel(const double* s1, const double* s2,
         if (r <= 0) 
             return 0;
         else 
-            res = fmin(r, res);
+            res = std::min(r, res);
     }
     return res;
 

--- a/rlpy/Representations/c_kernels.h
+++ b/rlpy/Representations/c_kernels.h
@@ -2,6 +2,8 @@
 #define KERNELS_H
 #include <vector>
 #include <cmath>
+#include <algorithm>
+
 double gaussian_kernel(const double* s1, const double* s2, 
                     const std::vector<unsigned int>& dim, 
                     const double* widths);


### PR DESCRIPTION
VC++ does not implement fmin.
This change allows the project to build and install on Windows machines using VC++ for Python 2.7

The variables 'r' and 'res' are of the same type: double, so this should be safe.