### PR TITLE
Changed GridWorld.__init__() 

### DIFF
--- a/rlpy/Domains/GridWorld.py
+++ b/rlpy/Domains/GridWorld.py
@@ -88,7 +88,10 @@ class GridWorld(Domain):
         self.DimNames = ['Row', 'Col']
         # 2*self.ROWS*self.COLS, small values can cause problem for some
         # planning techniques
-        self.episodeCap = 1000
+        if not self.episodeCap:
+            self.episodeCap = 1000
+        else:
+            self.episodeCap = episodeCap
         super(GridWorld, self).__init__()
 
     def showDomain(self, a=0, s=None):


### PR DESCRIPTION
We weren't able to redefine the number of steps per episode. Thus, GridWorld couldn't be used with larger grids. Now the default value is 1000, but it would accept any other value given in the constructor.