### PR TITLE
Inconsistencies with job_ids fixed

### DIFF
--- a/rlpy/Tools/hypersearch.py
+++ b/rlpy/Tools/hypersearch.py
@@ -247,7 +247,7 @@ def find_hyperparameters(
             "-".join([str(v) for v in hyperparam.values()]))
 
         # execute experiment
-        rt.run(setting, location=full_path, ids=range(1, trials_per_point + 1),
+        rt.run(setting, location=full_path, ids=range(trials_per_point),
                parallelization=parallelization, force_rerun=False, block=True, **hyperparam)
 
         # all jobs should be done
@@ -279,7 +279,7 @@ def find_hyperparameters(
                 "std_last_mean": std}
 
     if parallelization == "condor_all":
-        trials = CondorTrials(path=path, ids=range(1, trials_per_point + 1),
+        trials = CondorTrials(path=path, ids=range(trials_per_point),
                               setting=setting, objective=objective)
         domain = hyperopt.Domain(dummy_f, space, rseed=123)
         rval = hyperopt.FMinIter(hyperopt.rand.suggest, domain, trials,

--- a/rlpy/Tools/run.py
+++ b/rlpy/Tools/run.py
@@ -177,7 +177,7 @@ def run(filename, location, ids, parallelization="sequential",
 
     # filter ids if necessary
     if not force_rerun:
-        finished_ids = get_finished_ids(location)
+        finished_ids = [x-1 for x in get_finished_ids(location)]
         ids = [idtmp for idtmp in ids if idtmp not in finished_ids]
 
     if len(ids):


### PR DESCRIPTION
In run.py:

In the function run() in run.py, the ids should be provided as a list of
the form range(num_of_runs)
to create result-files beginning with 001-results.json.
As the list of ids should begin with 0, but the list of finished_ids
created by the get_finished_ids() function
is shifted by +1, the id filtering for the option force_rerun == False
is not working correctly

In hypersearch.py:

range(1, trials_per_point + 1) causes the enumeration of the
results.json files to be shifted
about + 1, as the job_id is incremented by 1 in the _run_helper function
within run.py

This leads to problems if the hyperparameter search is resumed.