### PR TITLE
Add support for python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Config.py
 .nfs*
 dist
 *.egg-info
+*.bak

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-virtualenv:
-    system_site_packages: true
 python:
     - "2.7.9"
     - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ before_install:
     - "sudo apt-get update -qq"
     - "sudo apt-get install python-tk python3-tk"
 install: 
-    - "pip install cython"
+    - "pip install cython matplotlib scikit-learn scipy"
     - "python setup.py develop"
 script: "xvfb-run --server-args=\"-screen 0 1024x768x24\" nosetests tests --logging-clear-handlers -v"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ virtualenv:
     system_site_packages: true
 python:
     - "2.7"
+    - "3.6"
 before_install:
     - "sudo apt-get update -qq"
     - "sudo apt-get install python-tk python-matplotlib python-sklearn python-scipy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ python:
     - "3.6"
 before_install:
     - "sudo apt-get update -qq"
-    - "sudo apt-get install python-tk python-matplotlib python-sklearn python-scipy"
+    - "sudo apt-get install python-tk python3-tk"
 install: 
     - "pip install cython"
     - "python setup.py develop"
-    - "sed -i \"/^\\/usr\\/lib/d\" /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/easy-install.pth || echo Error"
 script: "xvfb-run --server-args=\"-screen 0 1024x768x24\" nosetests tests --logging-clear-handlers -v"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 virtualenv:
     system_site_packages: true
 python:
-    - "2.7"
+    - "2.7.9"
     - "3.6"
 before_install:
     - "sudo apt-get update -qq"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 

--- a/examples/bicycle/kifdd_triangle.py
+++ b/examples/bicycle/kifdd_triangle.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 import rlpy
 import numpy as np
 from hyperopt import hp
@@ -34,8 +36,7 @@ def make_experiment(
 
     domain = rlpy.Domains.BicycleRiding()
     opt["domain"] = domain
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = rlpy.Representations.KernelizediFDD(domain, sparsify=sparsify,
                                kernel=rlpy.Representations.linf_triangle_kernel,
                                kernel_args=[kernel_width],

--- a/examples/bicycle/kifdd_triangle.py
+++ b/examples/bicycle/kifdd_triangle.py
@@ -1,4 +1,9 @@
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 import rlpy
 import numpy as np

--- a/examples/blocksworld/ggq-ifdd.py
+++ b/examples/blocksworld/ggq-ifdd.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/blocksworld/ggq-ifddkappa.py
+++ b/examples/blocksworld/ggq-ifddkappa.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/blocksworld/ggq-indep.py
+++ b/examples/blocksworld/ggq-indep.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/blocksworld/ggq-tile.py
+++ b/examples/blocksworld/ggq-tile.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import

--- a/examples/blocksworld/ggq-tile.py
+++ b/examples/blocksworld/ggq-tile.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/blocksworld/q-ifdd.py
+++ b/examples/blocksworld/q-ifdd.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/blocksworld/q-indep.py
+++ b/examples/blocksworld/q-indep.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/blocksworld/sarsa-ifdd.py
+++ b/examples/blocksworld/sarsa-ifdd.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import SARSA
 from rlpy.Representations import *

--- a/examples/blocksworld/sarsa-indep.py
+++ b/examples/blocksworld/sarsa-indep.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import BlocksWorld
 from rlpy.Agents import SARSA
 from rlpy.Representations import *

--- a/examples/cartpole2d/ggq-ifdd.py
+++ b/examples/cartpole2d/ggq-ifdd.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import Greedy_GQ, SARSA, Q_Learning
 from rlpy.Representations import *

--- a/examples/cartpole2d/ggq-indep.py
+++ b/examples/cartpole2d/ggq-indep.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import InfCartPoleBalance

--- a/examples/cartpole2d/ifdd.py
+++ b/examples/cartpole2d/ifdd.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import InfCartPoleBalance

--- a/examples/cartpole2d/kifdd_gauss.py
+++ b/examples/cartpole2d/kifdd_gauss.py
@@ -2,7 +2,12 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/cartpole2d/kifdd_gauss.py
+++ b/examples/cartpole2d/kifdd_gauss.py
@@ -1,7 +1,9 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
 
+from past.utils import old_div
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -42,10 +44,10 @@ def make_experiment(
 
     domain = InfCartPoleBalance()
     opt["domain"] = domain
-    kernel_width = (
+    kernel_width = old_div((
         domain.statespace_limits[:,
                                  1] - domain.statespace_limits[:,
-                                                               0]) / kernel_resolution
+                                                               0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,
                                kernel_args=[kernel_width],

--- a/examples/cartpole2d/kifdd_triangle.py
+++ b/examples/cartpole2d/kifdd_triangle.py
@@ -2,7 +2,12 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/cartpole2d/kifdd_triangle.py
+++ b/examples/cartpole2d/kifdd_triangle.py
@@ -1,7 +1,9 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
 
+from past.utils import old_div
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -43,10 +45,10 @@ def make_experiment(
 
     domain = InfCartPoleBalance()
     opt["domain"] = domain
-    kernel_width = (
+    kernel_width = old_div((
         domain.statespace_limits[:,
                                  1] - domain.statespace_limits[:,
-                                                               0]) / kernel_resolution
+                                                               0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=linf_triangle_kernel,
                                kernel_args=[kernel_width],

--- a/examples/cartpole2d/q-ifdd.py
+++ b/examples/cartpole2d/q-ifdd.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import InfCartPoleBalance

--- a/examples/cartpole2d/q-indep.py
+++ b/examples/cartpole2d/q-indep.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import InfCartPoleBalance

--- a/examples/cartpole2d/rbfs.py
+++ b/examples/cartpole2d/rbfs.py
@@ -1,6 +1,13 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/cartpole2d/sarsa-ifdd.py
+++ b/examples/cartpole2d/sarsa-ifdd.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import InfCartPoleBalance

--- a/examples/cartpole2d/sarsa-indep.py
+++ b/examples/cartpole2d/sarsa-indep.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import InfCartPoleBalance

--- a/examples/cartpole_modern/kifdd.py
+++ b/examples/cartpole_modern/kifdd.py
@@ -2,6 +2,11 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/cartpole_modern/kifdd.py
+++ b/examples/cartpole_modern/kifdd.py
@@ -1,6 +1,8 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
+from past.utils import old_div
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -39,8 +41,7 @@ def make_experiment(
 
     domain = FiniteCartPoleBalanceModern()
     opt["domain"] = domain
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
 
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,

--- a/examples/cartpole_orig/ifdd.py
+++ b/examples/cartpole_orig/ifdd.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *

--- a/examples/cartpole_orig/independent.py
+++ b/examples/cartpole_orig/independent.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *

--- a/examples/cartpole_orig/kifdd_gauss.py
+++ b/examples/cartpole_orig/kifdd_gauss.py
@@ -2,6 +2,11 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/cartpole_orig/kifdd_gauss.py
+++ b/examples/cartpole_orig/kifdd_gauss.py
@@ -1,6 +1,8 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
+from past.utils import old_div
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -43,8 +45,7 @@ def make_experiment(
     domain = FiniteCartPoleBalanceOriginal(good_reward=0.)
     opt["domain"] = domain
     # domain = FiniteCartPoleBalanceModern()
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,
                                kernel_args=[kernel_width],

--- a/examples/cartpole_orig/kifdd_triangle.py
+++ b/examples/cartpole_orig/kifdd_triangle.py
@@ -2,6 +2,11 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/cartpole_orig/kifdd_triangle.py
+++ b/examples/cartpole_orig/kifdd_triangle.py
@@ -1,6 +1,8 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
+from past.utils import old_div
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -43,8 +45,7 @@ def make_experiment(
     domain = FiniteCartPoleBalanceOriginal(good_reward=0.)
     opt["domain"] = domain
     # domain = FiniteCartPoleBalanceModern()
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=linf_triangle_kernel,
                                kernel_args=[kernel_width],

--- a/examples/cartpole_orig/rbfs.py
+++ b/examples/cartpole_orig/rbfs.py
@@ -1,6 +1,13 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *

--- a/examples/cartpole_orig/tabular.py
+++ b/examples/cartpole_orig/tabular.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.FiniteTrackCartPole import FiniteCartPoleBalanceOriginal, FiniteCartPoleBalanceModern
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/fifty_chain/tabular.py
+++ b/examples/fifty_chain/tabular.py
@@ -1,6 +1,12 @@
 """
 Fifty-State Chain with tabular representation, Q-Learning
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.FiftyChain import FiftyChain
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import Tabular

--- a/examples/gridworld/lspi.py
+++ b/examples/gridworld/lspi.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/gridworld/nac.py
+++ b/examples/gridworld/nac.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/gridworld/policy_iteration.py
+++ b/examples/gridworld/policy_iteration.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/gridworld/q-ifddk.py
+++ b/examples/gridworld/q-ifddk.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/gridworld/trajectory_based_policy_iteration.py
+++ b/examples/gridworld/trajectory_based_policy_iteration.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/gridworld/trajectory_based_value_iteration.py
+++ b/examples/gridworld/trajectory_based_value_iteration.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/gridworld/value_iteration.py
+++ b/examples/gridworld/value_iteration.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "William Dabney"
 
 from rlpy.Domains import GridWorld

--- a/examples/heli/kifdd.py
+++ b/examples/heli/kifdd.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 from rlpy.Domains import HelicopterHover
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *
@@ -40,8 +42,7 @@ def make_experiment(
     domain = HelicopterHover()
     opt["domain"] = domain
     # domain = FiniteCartPoleBalanceModern()
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=linf_triangle_kernel,
                                kernel_args=[kernel_width],

--- a/examples/heli/kifdd.py
+++ b/examples/heli/kifdd.py
@@ -1,4 +1,9 @@
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains import HelicopterHover
 from rlpy.Agents import Q_Learning

--- a/examples/hiv/ifdd.py
+++ b/examples/hiv/ifdd.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import HIVTreatment
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *

--- a/examples/hiv/independent.py
+++ b/examples/hiv/independent.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import HIVTreatment
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/hiv/kifdd.py
+++ b/examples/hiv/kifdd.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 from rlpy.Domains.HIVTreatment import HIVTreatment
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *
@@ -40,8 +42,7 @@ def make_experiment(
     domain = HIVTreatment()
     opt["domain"] = domain
     # domain = FiniteCartPoleBalanceModern()
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,
                                kernel_args=[kernel_width],

--- a/examples/hiv/kifdd.py
+++ b/examples/hiv/kifdd.py
@@ -1,4 +1,9 @@
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains.HIVTreatment import HIVTreatment
 from rlpy.Agents import Q_Learning

--- a/examples/hiv/kifdd_triangle.py
+++ b/examples/hiv/kifdd_triangle.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 from rlpy.Domains.HIVTreatment import HIVTreatment
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *
@@ -39,8 +41,7 @@ def make_experiment(
 
     domain = HIVTreatment()
     opt["domain"] = domain
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=linf_triangle_kernel,
                                kernel_args=[kernel_width],

--- a/examples/hiv/kifdd_triangle.py
+++ b/examples/hiv/kifdd_triangle.py
@@ -1,4 +1,9 @@
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains.HIVTreatment import HIVTreatment
 from rlpy.Agents import Q_Learning

--- a/examples/hiv/nplb_triangle.py
+++ b/examples/hiv/nplb_triangle.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import HIVTreatment
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *

--- a/examples/hiv/rbfs.py
+++ b/examples/hiv/rbfs.py
@@ -1,6 +1,13 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import HIVTreatment
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *

--- a/examples/hiv/tabular.py
+++ b/examples/hiv/tabular.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.HIVTreatment import HIVTreatment
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/intruder_monitoring/incr_tabular.py
+++ b/examples/intruder_monitoring/incr_tabular.py
@@ -1,6 +1,12 @@
 """
 Intruder Monitoring with incremental tabular representation, Q-Learning
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.IntruderMonitoring import IntruderMonitoring
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import IncrementalTabular

--- a/examples/intruder_monitoring/sarsa-ifdd.py
+++ b/examples/intruder_monitoring/sarsa-ifdd.py
@@ -1,6 +1,12 @@
 """
 Intruder Monitoring with iFDD representation, SARSA
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.IntruderMonitoring import IntruderMonitoring
 from rlpy.Agents import SARSA
 from rlpy.Representations import iFDD, IndependentDiscretization

--- a/examples/pacman/independent.py
+++ b/examples/pacman/independent.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import Pacman
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/puddleworld/ifdd.py
+++ b/examples/puddleworld/ifdd.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with iFDD+
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import os
 from rlpy.Domains import PuddleWorld

--- a/examples/puddleworld/kifdd_gauss.py
+++ b/examples/puddleworld/kifdd_gauss.py
@@ -1,7 +1,9 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
 
+from past.utils import old_div
 from rlpy.Domains import PuddleWorld
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -43,10 +45,10 @@ def make_experiment(
 
     domain = PuddleWorld()
     opt["domain"] = domain
-    kernel_width = (
+    kernel_width = old_div((
         domain.statespace_limits[:,
                                  1] - domain.statespace_limits[:,
-                                                               0]) / kernel_resolution
+                                                               0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,
                                kernel_args=[kernel_width],

--- a/examples/puddleworld/kifdd_gauss.py
+++ b/examples/puddleworld/kifdd_gauss.py
@@ -2,7 +2,12 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains import PuddleWorld
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/puddleworld/kifdd_gauss_gap.py
+++ b/examples/puddleworld/kifdd_gauss_gap.py
@@ -1,7 +1,9 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
 
+from past.utils import old_div
 from rlpy.Domains.PuddleWorld import PuddleGapWorld
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -43,10 +45,10 @@ def make_experiment(
 
     domain = PuddleGapWorld()
     opt["domain"] = domain
-    kernel_width = (
+    kernel_width = old_div((
         domain.statespace_limits[:,
                                  1] - domain.statespace_limits[:,
-                                                               0]) / kernel_resolution
+                                                               0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,
                                kernel_args=[kernel_width],

--- a/examples/puddleworld/kifdd_gauss_gap.py
+++ b/examples/puddleworld/kifdd_gauss_gap.py
@@ -2,7 +2,12 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains.PuddleWorld import PuddleGapWorld
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/puddleworld/kifdd_triangle.py
+++ b/examples/puddleworld/kifdd_triangle.py
@@ -1,7 +1,9 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import division
 
+from past.utils import old_div
 from rlpy.Domains import PuddleWorld
 from rlpy.Agents import SARSA, Q_LEARNING
 from rlpy.Representations import *
@@ -42,10 +44,10 @@ def make_experiment(
 
     domain = PuddleWorld()
     opt["domain"] = domain
-    kernel_width = (
+    kernel_width = old_div((
         domain.statespace_limits[:,
                                  1] - domain.statespace_limits[:,
-                                                               0]) / kernel_resolution
+                                                               0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=linf_triangle_kernel,
                                kernel_args=[kernel_width],

--- a/examples/puddleworld/kifdd_triangle.py
+++ b/examples/puddleworld/kifdd_triangle.py
@@ -2,7 +2,12 @@
 Cart-pole balancing with continuous / Kernelized iFDD
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Domains import PuddleWorld
 from rlpy.Agents import SARSA, Q_LEARNING

--- a/examples/puddleworld/rbfs.py
+++ b/examples/puddleworld/rbfs.py
@@ -1,6 +1,13 @@
 """
 Cart-pole balancing with independent discretization
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import PuddleWorld
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/puddleworld/tabular_gap.py
+++ b/examples/puddleworld/tabular_gap.py
@@ -1,7 +1,13 @@
 """
 Cart-pole balancing with continuous / Kernelized iFDD
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.PuddleWorld import PuddleGapWorld, PuddleWorld
 from rlpy.Agents import SARSA, Q_Learning
 from rlpy.Representations import *

--- a/examples/swimmer/kifdd_triangle.py
+++ b/examples/swimmer/kifdd_triangle.py
@@ -1,4 +1,9 @@
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/examples/swimmer/kifdd_triangle.py
+++ b/examples/swimmer/kifdd_triangle.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from builtins import str
+from builtins import range
+from past.utils import old_div
 from rlpy.Domains import Swimmer
 from rlpy.Agents import Q_Learning, SARSA
 from rlpy.Representations import *
@@ -40,8 +44,7 @@ def make_experiment(
 
     domain = Swimmer()
     opt["domain"] = domain
-    kernel_width = (domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]) \
-        / kernel_resolution
+    kernel_width = old_div((domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]), kernel_resolution)
     representation = KernelizediFDD(domain, sparsify=sparsify,
                                kernel=gaussian_kernel,
                                kernel_args=[kernel_width],

--- a/examples/system_administrator/incr_tabular.py
+++ b/examples/system_administrator/incr_tabular.py
@@ -1,6 +1,12 @@
 """
 System Administrator with incremental tabular representation, Q-Learning
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.SystemAdministrator import SystemAdministrator
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import IncrementalTabular

--- a/examples/system_administrator/sarsa-ifdd.py
+++ b/examples/system_administrator/sarsa-ifdd.py
@@ -1,6 +1,12 @@
 """
 System Administrator with iFDD representation, SARSA
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains.SystemAdministrator import SystemAdministrator
 from rlpy.Agents import SARSA
 from rlpy.Representations import iFDD, IndependentDiscretization

--- a/examples/tutorial/ChainMDPTut_example.py
+++ b/examples/tutorial/ChainMDPTut_example.py
@@ -7,6 +7,12 @@ Assumes you have created the ChainMDPTut.py domain according to the
 tutorial and placed it in the current working directory.
 Tests the agent using SARSA with a tabular representation.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "Robert H. Klein"
 from rlpy.Agents import SARSA
 from rlpy.Representations import Tabular

--- a/examples/tutorial/IncrTabularTut_example.py
+++ b/examples/tutorial/IncrTabularTut_example.py
@@ -7,6 +7,12 @@ Assumes you have created the IncrTabularTut.py agent according to the tutorial a
 placed it in the current working directory.
 Tests the Representation on the GridWorld domain usin SARSA
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "Robert H. Klein"
 from rlpy.Domains import GridWorld
 from rlpy.Agents import SARSA

--- a/examples/tutorial/SARSA0_example.py
+++ b/examples/tutorial/SARSA0_example.py
@@ -7,6 +7,12 @@ Assumes you have created the SARSA0.py agent according to the tutorial and
 placed it in the current working directory.
 Tests the agent on the GridWorld domain.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "Robert H. Klein"
 from rlpy.Domains import GridWorld
 from SARSA0 import SARSA0

--- a/examples/tutorial/eGreedyTut_example.py
+++ b/examples/tutorial/eGreedyTut_example.py
@@ -8,6 +8,12 @@ placed it in the current working directory.
 Tests the policy on the GridWorld domain, with the policy and value function
 visualized.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "Robert H. Klein"
 from rlpy.Domains import GridWorld
 from rlpy.Agents import SARSA

--- a/examples/tutorial/gridworld.py
+++ b/examples/tutorial/gridworld.py
@@ -6,6 +6,12 @@ Getting Started Tutorial for RLPy
 This file contains a very basic example of a RL experiment:
 A simple Grid-World.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "Robert H. Klein"
 from rlpy.Domains import GridWorld
 from rlpy.Agents import Q_Learning

--- a/examples/tutorial/gridworld_profiled.py
+++ b/examples/tutorial/gridworld_profiled.py
@@ -6,6 +6,12 @@ Getting Started Tutorial for RLPy
 This file contains a very basic example of a RL experiment:
 A simple Grid-World.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __author__ = "Robert H. Klein"
 from rlpy.Domains import GridWorld
 from rlpy.Agents import Q_Learning

--- a/examples/tutorial/infTrackCartPole_rbfs.py
+++ b/examples/tutorial/infTrackCartPole_rbfs.py
@@ -1,6 +1,13 @@
 """
 Cart-pole balancing with randomly positioned radial basis functions
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/tutorial/infTrackCartPole_tabular.py
+++ b/examples/tutorial/infTrackCartPole_tabular.py
@@ -1,6 +1,12 @@
 """
 Cart-pole balancing with tabular representation
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import InfCartPoleBalance
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/tutorial/paper_example.py
+++ b/examples/tutorial/paper_example.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 import rlpy
 #### Domain ####
 domain = rlpy.Domains.InfCartPoleBalance()

--- a/examples/tutorial/plot_result.py
+++ b/examples/tutorial/plot_result.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 import rlpy.Tools.results as rt
 
 paths = {"RBFs": "./Results/Tutorial/InfTrackCartPole/RBFs",

--- a/examples/tutorial/run_infTrackCartPole_batch.py
+++ b/examples/tutorial/run_infTrackCartPole_batch.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Tools.run import run
 run("examples/tutorial/infTrackCartPole_rbfs.py", "./Results/Tutorial/InfTrackCartPole/RBFs",

--- a/examples/tutorial/run_infTrackCartPole_batch.py
+++ b/examples/tutorial/run_infTrackCartPole_batch.py
@@ -1,6 +1,7 @@
+from builtins import range
 from rlpy.Tools.run import run
 run("examples/tutorial/infTrackCartPole_rbfs.py", "./Results/Tutorial/InfTrackCartPole/RBFs",
-    ids=range(10), parallelization="joblib")
+    ids=list(range(10)), parallelization="joblib")
 
 run("examples/tutorial/infTrackCartPole_tabular.py", "./Results/Tutorial/InfTrackCartPole/Tabular",
-    ids=range(10), parallelization="joblib")
+    ids=list(range(10)), parallelization="joblib")

--- a/examples/tutorial/run_parametersearch.py
+++ b/examples/tutorial/run_parametersearch.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from rlpy.Tools.hypersearch import find_hyperparameters
 best, trials = find_hyperparameters(
     "examples/tutorial/infTrackCartPole_rbfs.py",
     "./Results/Tutorial/InfTrackCartPole/RBFs_hypersearch",
     max_evals=10, parallelization="joblib",
     trials_per_point=5)
-print best
+print(best)

--- a/examples/tutorial/run_parametersearch.py
+++ b/examples/tutorial/run_parametersearch.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Tools.hypersearch import find_hyperparameters
 best, trials = find_hyperparameters(
     "examples/tutorial/infTrackCartPole_rbfs.py",

--- a/examples/uav/gq-ifdd.py
+++ b/examples/uav/gq-ifdd.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import PST
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/uav/gq-indep.py
+++ b/examples/uav/gq-indep.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import PST
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/uav/gql-ifdd.py
+++ b/examples/uav/gql-ifdd.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import PST
 from rlpy.Agents import Greedy_GQ
 from rlpy.Representations import *

--- a/examples/uav/q-ifdd.py
+++ b/examples/uav/q-ifdd.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import PST
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/examples/uav/q-indep.py
+++ b/examples/uav/q-indep.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Domains import PST
 from rlpy.Agents import Q_Learning
 from rlpy.Representations import *

--- a/rlpy/Agents/Agent.py
+++ b/rlpy/Agents/Agent.py
@@ -1,8 +1,12 @@
 """Standard Control Agent. """
+from __future__ import division
 
+from past.utils import old_div
+from builtins import object
 from abc import ABCMeta, abstractmethod
 import numpy as np
 import logging
+from future.utils import with_metaclass
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = ["Alborz Geramifard", "Robert H. Klein", "Christoph Dann",
@@ -11,7 +15,7 @@ __license__ = "BSD 3-Clause"
 __author__ = "Alborz Geramifard"
 
 
-class Agent(object):
+class Agent(with_metaclass(ABCMeta, object)):
 
     """Learning Agent for obtaining good policices.
 
@@ -43,8 +47,6 @@ class Agent(object):
         All new agent implementations should inherit from this class.
 
     """
-
-    __metaclass__ = ABCMeta
     # The Representation to be used by the Agent
     representation = None
     #: discount factor determining the optimal policy
@@ -213,7 +215,7 @@ class DescentAlgorithm(object):
                 candid_learn_rate = np.dot(discount_factor * phi_prime - phi,
                                                    eligibility_trace)
                 if candid_learn_rate < 0:
-                    self.learn_rate = np.minimum(self.learn_rate,-1.0/candid_learn_rate)
+                    self.learn_rate = np.minimum(self.learn_rate,old_div(-1.0,candid_learn_rate))
         elif self.learn_rate_decay_mode == 'boyan':
             self.learn_rate = self.initial_learn_rate * \
                 (self.boyan_N0 + 1.) / \

--- a/rlpy/Agents/Agent.py
+++ b/rlpy/Agents/Agent.py
@@ -1,6 +1,12 @@
 """Standard Control Agent. """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from builtins import object
 from abc import ABCMeta, abstractmethod

--- a/rlpy/Agents/BatchAgent.py
+++ b/rlpy/Agents/BatchAgent.py
@@ -1,4 +1,11 @@
 """An abstract class for Batch Learning Agents"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from .Agent import Agent
 import numpy as np
 

--- a/rlpy/Agents/Greedy_GQ.py
+++ b/rlpy/Agents/Greedy_GQ.py
@@ -1,5 +1,11 @@
 """Greedy-GQ(lambda) learning agent"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Agent import Agent, DescentAlgorithm
 from rlpy.Tools import addNewElementForAllActions, count_nonzero

--- a/rlpy/Agents/Greedy_GQ.py
+++ b/rlpy/Agents/Greedy_GQ.py
@@ -1,4 +1,6 @@
 """Greedy-GQ(lambda) learning agent"""
+from __future__ import division
+from past.utils import old_div
 from .Agent import Agent, DescentAlgorithm
 from rlpy.Tools import addNewElementForAllActions, count_nonzero
 import numpy as np
@@ -63,7 +65,7 @@ class Greedy_GQ(DescentAlgorithm, Agent):
             phi_prime_s)
         nnz = count_nonzero(phi_s)    # Number of non-zero elements
 
-        expanded = (- len(self.GQWeight) + len(phi)) / self.representation.actions_num
+        expanded = old_div((- len(self.GQWeight) + len(phi)), self.representation.actions_num)
         if expanded:
             self._expand_vectors(expanded)
         # Set eligibility traces:

--- a/rlpy/Agents/LSPI.py
+++ b/rlpy/Agents/LSPI.py
@@ -1,4 +1,5 @@
 """Least-Squares Policy Iteration [Lagoudakis and Parr 2003]."""
+from __future__ import print_function
 from .BatchAgent import BatchAgent
 import rlpy.Tools as Tools
 import numpy as np
@@ -133,7 +134,7 @@ class LSPI(BatchAgent):
         added_feature = True
 
         if self.representation.features_num == 0:
-            print "No features, hence no LSPI is necessary!"
+            print("No features, hence no LSPI is necessary!")
             return
 
         self.logger.info(

--- a/rlpy/Agents/LSPI.py
+++ b/rlpy/Agents/LSPI.py
@@ -1,5 +1,11 @@
 """Least-Squares Policy Iteration [Lagoudakis and Parr 2003]."""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from .BatchAgent import BatchAgent
 import rlpy.Tools as Tools
 import numpy as np

--- a/rlpy/Agents/LSPI_SARSA.py
+++ b/rlpy/Agents/LSPI_SARSA.py
@@ -1,4 +1,11 @@
 """Least-Squares Policy Iteration but with SARSA"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from .LSPI import LSPI
 from .TDControlAgent import SARSA
 

--- a/rlpy/Agents/NaturalActorCritic.py
+++ b/rlpy/Agents/NaturalActorCritic.py
@@ -2,6 +2,12 @@
 Experimental Implementation of Natural Actor Critic
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 import numpy as np
 from .Agent import Agent

--- a/rlpy/Agents/NaturalActorCritic.py
+++ b/rlpy/Agents/NaturalActorCritic.py
@@ -1,6 +1,8 @@
 """
 Experimental Implementation of Natural Actor Critic
 """
+from __future__ import division
+from past.utils import old_div
 import numpy as np
 from .Agent import Agent
 from rlpy.Tools import solveLinear, regularize
@@ -23,7 +25,7 @@ class NaturalActorCritic(Agent):
     """
 
     # minimum for the cosine of the current and last gradient
-    min_cos = np.cos(np.pi / 180.)
+    min_cos = np.cos(old_div(np.pi, 180.))
 
     def __init__(self, policy, representation, discount_factor, forgetting_rate,
                  min_steps_between_updates, max_steps_between_updates, lambda_,

--- a/rlpy/Agents/TDControlAgent.py
+++ b/rlpy/Agents/TDControlAgent.py
@@ -1,6 +1,11 @@
 """Control Agents based on TD Learning, i.e., Q-Learning and SARSA"""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Agent import Agent, DescentAlgorithm
 from rlpy.Tools import addNewElementForAllActions, count_nonzero

--- a/rlpy/Agents/TDControlAgent.py
+++ b/rlpy/Agents/TDControlAgent.py
@@ -1,4 +1,7 @@
 """Control Agents based on TD Learning, i.e., Q-Learning and SARSA"""
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
 from .Agent import Agent, DescentAlgorithm
 from rlpy.Tools import addNewElementForAllActions, count_nonzero
 import numpy as np
@@ -61,8 +64,8 @@ class TDControlAgent(DescentAlgorithm, Agent):
 
         # Set eligibility traces:
         if self.lambda_:
-            expanded = (- len(self.eligibility_trace) + len(phi)) / \
-                self.representation.actions_num
+            expanded = old_div((- len(self.eligibility_trace) + len(phi)), \
+                self.representation.actions_num)
             if expanded > 0:
                 # Correct the size of eligibility traces (pad with zeros for
                 # new features)
@@ -95,7 +98,7 @@ class TDControlAgent(DescentAlgorithm, Agent):
                 td_error * self.eligibility_trace
             if not np.all(np.isfinite(weight_vec)):
                 weight_vec = weight_vec_old
-                print "WARNING: TD-Learning diverged, weight_vec reached infinity!"
+                print("WARNING: TD-Learning diverged, weight_vec reached infinity!")
         # Discover features if the representation has the discover method
         expanded = self.representation.post_discover(
             s,

--- a/rlpy/Agents/__init__.py
+++ b/rlpy/Agents/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from .TDControlAgent import Q_Learning, SARSA
 # for compatibility of old scripts
 Q_LEARNING = Q_Learning

--- a/rlpy/Domains/Acrobot.py
+++ b/rlpy/Domains/Acrobot.py
@@ -1,4 +1,7 @@
 """classic Acrobot task"""
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 from rlpy.Tools import wrap, bound, lines, fromAtoB, rk4
 from .Domain import Domain
 import numpy as np
@@ -145,21 +148,20 @@ class Acrobot(Domain):
         d1 = m1 * lc1 ** 2 + m2 * \
             (l1 ** 2 + lc2 ** 2 + 2 * l1 * lc2 * np.cos(theta2)) + I1 + I2
         d2 = m2 * (lc2 ** 2 + l1 * lc2 * np.cos(theta2)) + I2
-        phi2 = m2 * lc2 * g * np.cos(theta1 + theta2 - np.pi / 2.)
+        phi2 = m2 * lc2 * g * np.cos(theta1 + theta2 - old_div(np.pi, 2.))
         phi1 = - m2 * l1 * lc2 * dtheta2 ** 2 * np.sin(theta2) \
                - 2 * m2 * l1 * lc2 * dtheta2 * dtheta1 * np.sin(theta2)  \
-            + (m1 * lc1 + m2 * l1) * g * np.cos(theta1 - np.pi / 2) + phi2
+            + (m1 * lc1 + m2 * l1) * g * np.cos(theta1 - old_div(np.pi, 2)) + phi2
         if self.book_or_nips == "nips":
             # the following line is consistent with the description in the
             # paper
-            ddtheta2 = (a + d2 / d1 * phi1 - phi2) / \
-                (m2 * lc2 ** 2 + I2 - d2 ** 2 / d1)
+            ddtheta2 = old_div((a + d2 / d1 * phi1 - phi2), \
+                (m2 * lc2 ** 2 + I2 - old_div(d2 ** 2, d1)))
         else:
             # the following line is consistent with the java implementation and the
             # book
-            ddtheta2 = (a + d2 / d1 * phi1 - m2 * l1 * lc2 * dtheta1 ** 2 * np.sin(theta2) - phi2) \
-                / (m2 * lc2 ** 2 + I2 - d2 ** 2 / d1)
-        ddtheta1 = -(d2 * ddtheta2 + phi1) / d1
+            ddtheta2 = old_div((a + d2 / d1 * phi1 - m2 * l1 * lc2 * dtheta1 ** 2 * np.sin(theta2) - phi2), (m2 * lc2 ** 2 + I2 - old_div(d2 ** 2, d1)))
+        ddtheta1 = old_div(-(d2 * ddtheta2 + phi1), d1)
         return (dtheta1, dtheta2, ddtheta1, ddtheta2, 0.)
 
     def showDomain(self, a=0):
@@ -197,12 +199,12 @@ class Acrobot(Domain):
         torque = self.AVAIL_TORQUE[a]
         SHIFT = .5
         if torque > 0:  # counterclockwise torque
-            self.action_arrow = fromAtoB(SHIFT / 2.0, .5 * SHIFT, -SHIFT / 2.0,
+            self.action_arrow = fromAtoB(old_div(SHIFT, 2.0), .5 * SHIFT, old_div(-SHIFT, 2.0),
                                          -.5 * SHIFT, 'k', connectionstyle="arc3,rad=+1.2",
                                          ax=self.domain_ax)
         elif torque < 0:  # clockwise torque
             self.action_arrow = fromAtoB(
-                -SHIFT / 2.0, .5 * SHIFT, +SHIFT / 2.0,
+                old_div(-SHIFT, 2.0), .5 * SHIFT, old_div(+SHIFT, 2.0),
                 -.5 * SHIFT, 'r', connectionstyle="arc3,rad=-1.2",
                 ax=self.domain_ax)
 

--- a/rlpy/Domains/Acrobot.py
+++ b/rlpy/Domains/Acrobot.py
@@ -1,5 +1,10 @@
 """classic Acrobot task"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 from rlpy.Tools import wrap, bound, lines, fromAtoB, rk4

--- a/rlpy/Domains/Bicycle.py
+++ b/rlpy/Domains/Bicycle.py
@@ -182,10 +182,11 @@ class BicycleBalancing(Domain):
             ax.set_xlabel("Days")
         for i in range(n):
             handles[i].set_ydata(self.episode_data[i])
-            ax = handles[i].get_axes()
+            ax = handles[i].axes
             ax.relim()
             ax.autoscale_view()
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()
 
 
 class BicycleRiding(BicycleBalancing):

--- a/rlpy/Domains/Bicycle.py
+++ b/rlpy/Domains/Bicycle.py
@@ -1,6 +1,11 @@
 """Bicycle balancing task."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 from .Domain import Domain

--- a/rlpy/Domains/Bicycle.py
+++ b/rlpy/Domains/Bicycle.py
@@ -1,5 +1,8 @@
 """Bicycle balancing task."""
+from __future__ import division
 
+from builtins import range
+from past.utils import old_div
 from .Domain import Domain
 import numpy as np
 from itertools import product
@@ -76,7 +79,7 @@ class BicycleBalancing(Domain):
         T, d = self.actions[a]
         omega, domega, theta, dtheta, psi = s
 
-        v = 10 / 3.6
+        v = old_div(10, 3.6)
         g = 9.82
         d_CM = 0.3
         c = 0.66
@@ -86,7 +89,7 @@ class BicycleBalancing(Domain):
         M_p = 60.
         M = M_c + M_p
         r = 0.34
-        dsigma = v / r
+        dsigma = old_div(v, r)
         I = 13 / 3. * M_c * h ** 2 + M_p * (h + d_CM) ** 2
         I_dc = M_d * r ** 2
         I_dv = 3 / 2. * M_d * r ** 2
@@ -95,9 +98,9 @@ class BicycleBalancing(Domain):
 
         w = self.random_state.uniform(-0.02, 0.02)
 
-        phi = omega + np.arctan(d + w) / h
-        invr_f = np.abs(np.sin(theta)) / l
-        invr_b = np.abs(np.tan(theta)) / l
+        phi = omega + old_div(np.arctan(d + w), h)
+        invr_f = old_div(np.abs(np.sin(theta)), l)
+        invr_b = old_div(np.abs(np.tan(theta)), l)
         invr_CM = ((l - c) ** 2 + invr_b ** (-2)
                    ) ** (-.5) if theta != 0. else 0.
 
@@ -106,11 +109,11 @@ class BicycleBalancing(Domain):
                                       (I_dc * dsigma * dtheta +
                                        np.sign(theta) * v ** 2 * (M_d * r * (invr_f + invr_b) + M * h * invr_CM))) / I
         out = theta + self.dt * dtheta
-        ntheta = out if abs(out) <= (80. / 180) * \
-            np.pi else np.sign(out) * (80. / 180) * np.pi
+        ntheta = out if abs(out) <= (old_div(80., 180)) * \
+            np.pi else np.sign(out) * (old_div(80., 180)) * np.pi
         ndtheta = dtheta + self.dt * \
             (T - I_dv * dsigma * domega) / \
-            I_dl if abs(out) <= (80. / 180) * np.pi else 0.
+            I_dl if abs(out) <= (old_div(80., 180)) * np.pi else 0.
         npsi = psi + self.dt * np.sign(theta) * v * invr_b
 
         # Where are these three lines from? Having a hard time finding them in

--- a/rlpy/Domains/BlocksWorld.py
+++ b/rlpy/Domains/BlocksWorld.py
@@ -1,5 +1,8 @@
 """BlocksWorld domain, stacking of blocks to form a tower."""
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
 from .Domain import Domain
 from rlpy.Tools import id2vec, vec2id, findElemArray1D
 from rlpy.Tools import nchoosek, factorial, findElemArray2D, plt, FONTSIZE
@@ -77,12 +80,12 @@ class BlocksWorld(Domain):
         self.real_states_num = sum(
             [nchoosek(blocks,
                       i) * factorial(blocks - i) * pow(i,
-                                                       blocks - i) for i in xrange(blocks)])
+                                                       blocks - i) for i in range(blocks)])
         # [0 0 1 2 3 .. blocks-2] meaning block 0 on the table and all other stacked on top of e
         self.GOAL_STATE = np.hstack(([0], np.arange(0, blocks - 1)))
         # Make Dimension Names
         self.DimNames = []
-        for a in xrange(blocks):
+        for a in range(blocks):
             self.DimNames.append(['%d on' % a])
         super(BlocksWorld, self).__init__()
 
@@ -129,9 +132,9 @@ class BlocksWorld(Domain):
         [A, B] = id2vec(a, [self.blocks, self.blocks])
         # print 'taking action %d->%d' % (A,B)
         if not self.validAction(s, A, B):
-            print 'State:%s, Invalid move from %d to %d' % (str(s), A, B)
-            print self.possibleActions()
-            print id2vec(self.possibleActions(), [self.blocks, self.blocks])
+            print('State:%s, Invalid move from %d to %d' % (str(s), A, B))
+            print(self.possibleActions())
+            print(id2vec(self.possibleActions(), [self.blocks, self.blocks]))
 
         if self.random_state.random_sample() < self.noise:
             B = A  # Drop on Table
@@ -151,7 +154,7 @@ class BlocksWorld(Domain):
         s = self.state
         # return the id of possible actions
         # find empty blocks (nothing on top)
-        empty_blocks = [b for b in xrange(self.blocks) if self.clear(b, s)]
+        empty_blocks = [b for b in range(self.blocks) if self.clear(b, s)]
         actions = [[a,
                     b] for a in empty_blocks for b in empty_blocks if not self.destination_is_table(
             a,

--- a/rlpy/Domains/BlocksWorld.py
+++ b/rlpy/Domains/BlocksWorld.py
@@ -1,6 +1,12 @@
 """BlocksWorld domain, stacking of blocks to form a tower."""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from .Domain import Domain

--- a/rlpy/Domains/BlocksWorld.py
+++ b/rlpy/Domains/BlocksWorld.py
@@ -109,6 +109,7 @@ class BlocksWorld(Domain):
                     # Put it in the back of the list
                     undrawn_blocks = np.hstack((undrawn_blocks, [A]))
         if self.domain_fig is None:
+            plt.figure("Domain")
             self.domain_fig = plt.imshow(
                 world,
                 cmap='BlocksWorld',
@@ -121,7 +122,8 @@ class BlocksWorld(Domain):
             plt.show()
         else:
             self.domain_fig.set_data(world)
-            plt.draw()
+            plt.figure("Domain").canvas.draw()
+            plt.figure("Domain").canvas.flush_events()
 
     def showLearning(self, representation):
         pass  # cant show 6 dimensional value function

--- a/rlpy/Domains/CartPoleBase.py
+++ b/rlpy/Domains/CartPoleBase.py
@@ -1,10 +1,16 @@
 """Base class for all cartpole domains"""
+from __future__ import division
+from __future__ import print_function
 
+from builtins import range
+from builtins import object
+from past.utils import old_div
 from .Domain import Domain
 import numpy as np
 import scipy.integrate
 from rlpy.Tools import pl, mpatches, mpath, fromAtoB, lines, rk4, wrap, bound, colors
 from abc import ABCMeta, abstractproperty
+from future.utils import with_metaclass
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = ["Alborz Geramifard", "Robert H. Klein", "Christoph Dann",
@@ -13,7 +19,7 @@ __license__ = "BSD 3-Clause"
 pi = np.pi
 
 
-class CartPoleBase(Domain):
+class CartPoleBase(with_metaclass(ABCMeta, Domain)):
 
     """
     Base class for all CartPole domains.  Dynamics shared across all, but
@@ -37,7 +43,6 @@ class CartPoleBase(Domain):
     """
 
     __author__ = ["Robert H. Klein"]
-    __metaclass__ = ABCMeta
 
 
     @abstractproperty
@@ -118,7 +123,7 @@ class CartPoleBase(Domain):
     RECT_WIDTH = 0.5   # width of cart rectangle
     RECT_HEIGHT = 0.4   # height of cart rectangle
     # visual square at cart center of mass
-    BLOB_WIDTH = RECT_HEIGHT / 2.0
+    BLOB_WIDTH = old_div(RECT_HEIGHT, 2.0)
     PEND_WIDTH = 2     # width of pendulum arm rectangle
     GROUND_WIDTH = 2     # width of ground rectangle
     GROUND_HEIGHT = 1     # height of ground rectangle
@@ -168,10 +173,10 @@ class CartPoleBase(Domain):
             the pendulum to spin with angular rate in multiples of
             2pi / dt instead of truly remaining stationary (0 rad/s) at goal.
             """
-            print errStr
-            print 'Your selection, dt=', self.dt, 'and limits', self.ANGULAR_RATE_LIMITS, 'Are at risk.'
-            print 'Reduce your timestep dt (to increase # timesteps) or reduce angular rate limits so that 2pi / dt > max(AngularRateLimit)'
-            print 'Currently, 2pi / dt = ', 2 * pi / self.dt, ', angular rate limits shown above.'
+            print(errStr)
+            print('Your selection, dt=', self.dt, 'and limits', self.ANGULAR_RATE_LIMITS, 'Are at risk.')
+            print('Reduce your timestep dt (to increase # timesteps) or reduce angular rate limits so that 2pi / dt > max(AngularRateLimit)')
+            print('Currently, 2pi / dt = ', 2 * pi / self.dt, ', angular rate limits shown above.')
             return False
 
         return True
@@ -188,22 +193,22 @@ class CartPoleBase(Domain):
 
         """
         if self.POSITION_LIMITS[0] < -100 * self.LENGTH or self.POSITION_LIMITS[1] > 100 * self.LENGTH:
-            self.minPosition = 0 - self.RECT_WIDTH / 2.0
-            self.maxPosition = 0 + self.RECT_WIDTH / 2.0
+            self.minPosition = 0 - old_div(self.RECT_WIDTH, 2.0)
+            self.maxPosition = 0 + old_div(self.RECT_WIDTH, 2.0)
         else:
-            self.minPosition = self.POSITION_LIMITS[0] - self.RECT_WIDTH / 2.0
-            self.maxPosition = self.POSITION_LIMITS[1] + self.RECT_WIDTH / 2.0
+            self.minPosition = self.POSITION_LIMITS[0] - old_div(self.RECT_WIDTH, 2.0)
+            self.maxPosition = self.POSITION_LIMITS[1] + old_div(self.RECT_WIDTH, 2.0)
         self.GROUND_VERTS = np.array([
-            (self.minPosition, -self.RECT_HEIGHT / 2.0),
-            (self.minPosition, self.RECT_HEIGHT / 2.0),
-            (self.minPosition - self.GROUND_WIDTH, self.RECT_HEIGHT / 2.0),
+            (self.minPosition, old_div(-self.RECT_HEIGHT, 2.0)),
+            (self.minPosition, old_div(self.RECT_HEIGHT, 2.0)),
+            (self.minPosition - self.GROUND_WIDTH, old_div(self.RECT_HEIGHT, 2.0)),
             (self.minPosition - self.GROUND_WIDTH,
-             self.RECT_HEIGHT / 2.0 - self.GROUND_HEIGHT),
+             old_div(self.RECT_HEIGHT, 2.0) - self.GROUND_HEIGHT),
             (self.maxPosition + self.GROUND_WIDTH,
-             self.RECT_HEIGHT / 2.0 - self.GROUND_HEIGHT),
-            (self.maxPosition + self.GROUND_WIDTH, self.RECT_HEIGHT / 2.0),
-            (self.maxPosition, self.RECT_HEIGHT / 2.0),
-            (self.maxPosition, -self.RECT_HEIGHT / 2.0),
+             old_div(self.RECT_HEIGHT, 2.0) - self.GROUND_HEIGHT),
+            (self.maxPosition + self.GROUND_WIDTH, old_div(self.RECT_HEIGHT, 2.0)),
+            (self.maxPosition, old_div(self.RECT_HEIGHT, 2.0)),
+            (self.maxPosition, old_div(-self.RECT_HEIGHT, 2.0)),
         ])
 
     def _getReward(self, a, s=None):
@@ -352,7 +357,7 @@ class CartPoleBase(Domain):
         # g sin(theta) - (alpha)ml(tdot)^2 * sin(2theta)/2  -  (alpha)cos(theta)u
         # ---------------------------------------------------------------------
         #                     4l/3  -  (alpha)ml*cos^2(theta)
-        thetaDotDot = numer / denom
+        thetaDotDot = old_div(numer, denom)
 
         xDotDot = term1 - m_pendAlphaTimesL * thetaDotDot * cosTheta
         return (
@@ -466,13 +471,13 @@ class CartPoleBase(Domain):
                 color='black')
             self.cartBox = mpatches.Rectangle(
                 [0,
-                 self.PENDULUM_PIVOT_Y - self.RECT_HEIGHT / 2.0],
+                 self.PENDULUM_PIVOT_Y - old_div(self.RECT_HEIGHT, 2.0)],
                 self.RECT_WIDTH,
                 self.RECT_HEIGHT,
                 alpha=.4)
             self.cartBlob = mpatches.Rectangle(
                 [0,
-                 self.PENDULUM_PIVOT_Y - self.BLOB_WIDTH / 2.0],
+                 self.PENDULUM_PIVOT_Y - old_div(self.BLOB_WIDTH, 2.0)],
                 self.BLOB_WIDTH,
                 self.BLOB_WIDTH,
                 alpha=.4)
@@ -514,13 +519,13 @@ class CartPoleBase(Domain):
         pendulumBobY = self.PENDULUM_PIVOT_Y + self.LENGTH * np.cos(curTheta)
 
         if self.DEBUG:
-            print 'Pendulum Position: ', pendulumBobX, pendulumBobY
+            print('Pendulum Position: ', pendulumBobX, pendulumBobY)
 
         # update pendulum arm on figure
         self.pendulumArm.set_data(
             [curX, pendulumBobX], [self.PENDULUM_PIVOT_Y, pendulumBobY])
-        self.cartBox.set_x(curX - self.RECT_WIDTH / 2.0)
-        self.cartBlob.set_x(curX - self.BLOB_WIDTH / 2.0)
+        self.cartBox.set_x(curX - old_div(self.RECT_WIDTH, 2.0))
+        self.cartBlob.set_x(curX - old_div(self.BLOB_WIDTH, 2.0))
 
         if self.actionArrow is not None:
             self.actionArrow.remove()
@@ -531,15 +536,15 @@ class CartPoleBase(Domain):
         else:  # cw or ccw torque
             if forceAction > 0:  # rightward force
                 self.actionArrow = fromAtoB(
-                    curX - self.ACTION_ARROW_LENGTH - self.RECT_WIDTH / 2.0, 0,
-                    curX - self.RECT_WIDTH / 2.0, 0,
+                    curX - self.ACTION_ARROW_LENGTH - old_div(self.RECT_WIDTH, 2.0), 0,
+                    curX - old_div(self.RECT_WIDTH, 2.0), 0,
                     'k', "arc3,rad=0",
                     0, 0, 'simple', ax=self.domain_ax
                 )
             else:  # leftward force
                 self.actionArrow = fromAtoB(
-                    curX + self.ACTION_ARROW_LENGTH + self.RECT_WIDTH / 2.0, 0,
-                    curX + self.RECT_WIDTH / 2.0, 0,
+                    curX + self.ACTION_ARROW_LENGTH + old_div(self.RECT_WIDTH, 2.0), 0,
+                    curX + old_div(self.RECT_WIDTH, 2.0), 0,
                     'r', "arc3,rad=0",
                     0, 0, 'simple', ax=self.domain_ax
                 )
@@ -565,17 +570,17 @@ class CartPoleBase(Domain):
 
         # Create the center of the grid cells both in theta and
         # thetadot_dimension
-        theta_binWidth = (
-            self.ANGLE_LIMITS[1] - self.ANGLE_LIMITS[0]) / (thetaDiscr * granularity)
+        theta_binWidth = old_div((
+            self.ANGLE_LIMITS[1] - self.ANGLE_LIMITS[0]), (thetaDiscr * granularity))
         thetas = np.linspace(
-            self.ANGLE_LIMITS[0] + theta_binWidth / 2,
-            self.ANGLE_LIMITS[1] - theta_binWidth / 2,
+            self.ANGLE_LIMITS[0] + old_div(theta_binWidth, 2),
+            self.ANGLE_LIMITS[1] - old_div(theta_binWidth, 2),
             thetaDiscr * granularity)
-        theta_dot_binWidth = (
-            self.ANGULAR_RATE_LIMITS[1] - self.ANGULAR_RATE_LIMITS[0]) / (thetaDotDiscr * granularity)
+        theta_dot_binWidth = old_div((
+            self.ANGULAR_RATE_LIMITS[1] - self.ANGULAR_RATE_LIMITS[0]), (thetaDotDiscr * granularity))
         theta_dots = np.linspace(
-            self.ANGULAR_RATE_LIMITS[0] + theta_dot_binWidth / 2,
-            self.ANGULAR_RATE_LIMITS[1] - theta_dot_binWidth / 2,
+            self.ANGULAR_RATE_LIMITS[0] + old_div(theta_dot_binWidth, 2),
+            self.ANGULAR_RATE_LIMITS[1] - old_div(theta_dot_binWidth, 2),
             thetaDotDiscr * granularity)
 
         self.xTicks = np.linspace(0, granularity * thetaDiscr - 1, 5)
@@ -603,7 +608,7 @@ class CartPoleBase(Domain):
         return [ns]
 
 
-class StateIndex:
+class StateIndex(object):
 
     """
     Flexible way to index states in the CartPole Domain.

--- a/rlpy/Domains/CartPoleBase.py
+++ b/rlpy/Domains/CartPoleBase.py
@@ -1,7 +1,12 @@
 """Base class for all cartpole domains"""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from builtins import object
 from past.utils import old_div

--- a/rlpy/Domains/ChainMDP.py
+++ b/rlpy/Domains/ChainMDP.py
@@ -1,4 +1,11 @@
 """Simple Chain MDP domain."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Tools import plt, mpatches, fromAtoB
 from .Domain import Domain

--- a/rlpy/Domains/ChainMDP.py
+++ b/rlpy/Domains/ChainMDP.py
@@ -1,4 +1,5 @@
 """Simple Chain MDP domain."""
+from builtins import range
 from rlpy.Tools import plt, mpatches, fromAtoB
 from .Domain import Domain
 import numpy as np
@@ -88,8 +89,8 @@ class ChainMDP(Domain):
             ax.xaxis.set_visible(False)
             ax.yaxis.set_visible(False)
             self.circles = [mpatches.Circle((1 + 2 * i, self.Y), self.RADIUS, fc="w")
-                            for i in xrange(self.chainSize)]
-            for i in xrange(self.chainSize):
+                            for i in range(self.chainSize)]
+            for i in range(self.chainSize):
                 ax.add_patch(self.circles[i])
                 if i != self.chainSize - 1:
                     fromAtoB(

--- a/rlpy/Domains/Domain.py
+++ b/rlpy/Domains/Domain.py
@@ -1,4 +1,11 @@
 """Domain base class"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from builtins import object
 import numpy as np

--- a/rlpy/Domains/Domain.py
+++ b/rlpy/Domains/Domain.py
@@ -1,4 +1,6 @@
 """Domain base class"""
+from builtins import range
+from builtins import object
 import numpy as np
 import logging
 from copy import deepcopy
@@ -262,7 +264,7 @@ Gamma:      {self.discount_factor}
         # Store the original limits for other types of calculations
         self.discrete_statespace_limits = self.statespace_limits
         self.statespace_limits = self.statespace_limits.astype('float')
-        for d in xrange(self.state_space_dims):
+        for d in range(self.state_space_dims):
             if d not in self.continuous_dims:
                 self.statespace_limits[d, 0] += -.5
                 self.statespace_limits[d, 1] += +.5
@@ -287,7 +289,7 @@ Gamma:      {self.discount_factor}
         next_states = []
         rewards = []
         s = self.state.copy()
-        for i in xrange(num_samples):
+        for i in range(num_samples):
             r, ns, terminal = self.step(a)
             self.state = s.copy()
             next_states.append(ns)
@@ -305,7 +307,7 @@ Gamma:      {self.discount_factor}
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
-        for k, v in self.__dict__.items():
+        for k, v in list(self.__dict__.items()):
             if k is "logger":
                 continue
             # This block bandles matplotlib transformNode objects,

--- a/rlpy/Domains/FiftyChain.py
+++ b/rlpy/Domains/FiftyChain.py
@@ -172,6 +172,7 @@ class FiftyChain(Domain):
         s = self.state
         # Draw the environment
         if self.circles is None:
+            plt.figure("Domain")
             self.domain_fig = plt.subplot(3, 1, 1)
             plt.figure(1, (self.chainSize * 2 / 10.0, 2))
             self.domain_fig.set_xlim(0, self.chainSize * 2 / 10.0)
@@ -193,7 +194,8 @@ class FiftyChain(Domain):
         for p in self.GOAL_STATES:
             self.circles[p].set_facecolor('g')
         self.circles[s].set_facecolor('k')
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()
 
     def showLearning(self, representation):
         allStates = np.arange(0, self.chainSize)

--- a/rlpy/Domains/FiftyChain.py
+++ b/rlpy/Domains/FiftyChain.py
@@ -1,5 +1,8 @@
 """Fifty state chain."""
+from __future__ import division
 
+from builtins import range
+from past.utils import old_div
 from rlpy.Tools import plt, mpatches
 import numpy as np
 from .Domain import Domain
@@ -139,7 +142,7 @@ class FiftyChain(Domain):
         self.statespace_limits = np.array([[0, self.chainSize - 1]])
         super(FiftyChain, self).__init__()
         # To catch errors
-        self.optimal_policy = np.array([-1 for dummy in xrange(0, self.chainSize)])
+        self.optimal_policy = np.array([-1 for dummy in range(0, self.chainSize)])
         self.storeOptimalPolicy()
         self.discount_factor = 0.8  # Set discount_factor to be 0.8 for this domain per L & P 2007
 
@@ -174,13 +177,13 @@ class FiftyChain(Domain):
             self.domain_fig.set_xlim(0, self.chainSize * 2 / 10.0)
             self.domain_fig.set_ylim(0, 2)
             self.domain_fig.add_patch(
-                mpatches.Circle((1 / 5.0 + 2 / 10.0 * (self.chainSize - 1),
+                mpatches.Circle((old_div(1, 5.0) + 2 / 10.0 * (self.chainSize - 1),
                                  self.Y),
                                 self.RADIUS * 1.1,
                                 fc="w"))  # Make the last one double circle
             self.domain_fig.xaxis.set_visible(False)
             self.domain_fig.yaxis.set_visible(False)
-            self.circles = [mpatches.Circle((1 / 5.0 + 2 / 10.0 * i, self.Y), self.RADIUS, fc="w")
+            self.circles = [mpatches.Circle((old_div(1, 5.0) + 2 / 10.0 * i, self.Y), self.RADIUS, fc="w")
                             for i in range(self.chainSize)]
             for i in range(self.chainSize):
                 self.domain_fig.add_patch(self.circles[i])
@@ -286,5 +289,5 @@ class FiftyChain(Domain):
             and the optimal one.
         """
         V = np.array([representation.V(s, False, self.possibleActions(s=s)) \
-                      for s in xrange(self.chainSize)])
+                      for s in range(self.chainSize)])
         return np.linalg.norm(V - self.V_star, np.inf)

--- a/rlpy/Domains/FiftyChain.py
+++ b/rlpy/Domains/FiftyChain.py
@@ -1,6 +1,13 @@
 """Fifty state chain."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 from rlpy.Tools import plt, mpatches

--- a/rlpy/Domains/FiniteTrackCartPole.py
+++ b/rlpy/Domains/FiniteTrackCartPole.py
@@ -1,6 +1,12 @@
 """Cart with a pole domains"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Domain import Domain
 from .CartPoleBase import CartPoleBase, StateIndex

--- a/rlpy/Domains/FiniteTrackCartPole.py
+++ b/rlpy/Domains/FiniteTrackCartPole.py
@@ -1,5 +1,7 @@
 """Cart with a pole domains"""
+from __future__ import division
 
+from past.utils import old_div
 from .Domain import Domain
 from .CartPoleBase import CartPoleBase, StateIndex
 import numpy as np
@@ -63,7 +65,7 @@ class FiniteTrackCartPole(CartPoleBase):
     __author__ = ["Robert H. Klein"]
 
     #: Default limits on theta
-    ANGLE_LIMITS = [-pi / 15.0, pi / 15.0]
+    ANGLE_LIMITS = [old_div(-pi, 15.0), old_div(pi, 15.0)]
     #: Default limits on pendulum rate
     ANGULAR_RATE_LIMITS = [-2.0, 2.0]
     #: m - Default limits on cart position [Per RL Community CartPole]
@@ -81,10 +83,10 @@ class FiniteTrackCartPole(CartPoleBase):
     #: meters, m - Physical length of the pendulum, meters (note the moment-arm lies at half this distance)
     LENGTH = 1.0
     # m - Length of moment-arm to center of mass (= half the pendulum length)
-    MOMENT_ARM = LENGTH / 2.
+    MOMENT_ARM = old_div(LENGTH, 2.)
     # 1/kg - Used in dynamics computations, equal to 1 / (MASS_PEND +
     # MASS_CART)
-    _ALPHA_MASS = 1.0 / (MASS_CART + MASS_PEND)
+    _ALPHA_MASS = old_div(1.0, (MASS_CART + MASS_PEND))
     #: seconds, s - Time between steps
     dt = 0.02
     #: Newtons, N - Maximum noise possible, uniformly distributed.  Default 0.
@@ -213,13 +215,13 @@ class FiniteCartPoleBalance(FiniteTrackCartPole):
         if s is None:
             s = self.state
         return (
-            self.GOAL_REWARD if -pi / 15 < s[StateIndex.THETA] < pi / 15 else 0
+            self.GOAL_REWARD if old_div(-pi, 15) < s[StateIndex.THETA] < old_div(pi, 15) else 0
         )
 
     def isTerminal(self, s=None):
         if s is None:
             s = self.state
-        return (not (-pi / 15 < s[StateIndex.THETA] < pi / 15) or
+        return (not (old_div(-pi, 15) < s[StateIndex.THETA] < old_div(pi, 15)) or
                 not (-2.4 < s[StateIndex.X] < 2.4))
 
 
@@ -256,7 +258,7 @@ class FiniteCartPoleBalanceOriginal(FiniteTrackCartPole):
     def isTerminal(self, s=None):
         if s is None:
             s = self.state
-        return (not (-np.pi / 15 < s[StateIndex.THETA] < np.pi / 15) or
+        return (not (old_div(-np.pi, 15) < s[StateIndex.THETA] < old_div(np.pi, 15)) or
                 not (-2.4 < s[StateIndex.X] < 2.4))
 
 
@@ -293,7 +295,7 @@ class FiniteCartPoleBalanceModern(FiniteTrackCartPole):
     def isTerminal(self, s=None):
         if s is None:
             s = self.state
-        return (not (-np.pi / 15 < s[StateIndex.THETA] < np.pi / 15) or
+        return (not (old_div(-np.pi, 15) < s[StateIndex.THETA] < old_div(np.pi, 15)) or
                 not (-2.4 < s[StateIndex.X] < 2.4))
 
 
@@ -334,7 +336,7 @@ class FiniteCartPoleSwingUp(FiniteTrackCartPole):
         if s is None:
             s = self.state
         return (
-            self.GOAL_REWARD if -pi / 6 < s[StateIndex.THETA] < pi / 6 else 0
+            self.GOAL_REWARD if old_div(-pi, 6) < s[StateIndex.THETA] < old_div(pi, 6) else 0
         )
 
     def isTerminal(self, s=None):
@@ -425,9 +427,7 @@ class FiniteCartPoleSwingUpFriction(FiniteCartPoleSwingUp):
         g = self.ACCEL_G
         ds = np.zeros(4)
         ds[0] = s[1]
-        ds[1] = (2 * m * l * s[2] ** 2 * s3 + 3 * m * g * s3 * c3 + 4 * a - 4 * b * s[1])\
-            / (4 * (M + m) - 3 * m * c3 ** 2)
-        ds[2] = (-3 * m * l * s[2] ** 2 * s3 * c3 - 6 * (M + m) * g * s3 - 6 * (a - b * s[1]) * c3)\
-            / (4 * l * (m + M) - 3 * m * l * c3 ** 2)
+        ds[1] = old_div((2 * m * l * s[2] ** 2 * s3 + 3 * m * g * s3 * c3 + 4 * a - 4 * b * s[1]), (4 * (M + m) - 3 * m * c3 ** 2))
+        ds[2] = old_div((-3 * m * l * s[2] ** 2 * s3 * c3 - 6 * (M + m) * g * s3 - 6 * (a - b * s[1]) * c3), (4 * l * (m + M) - 3 * m * l * c3 ** 2))
         ds[3] = s[2]
         return ds

--- a/rlpy/Domains/FlipBoard.py
+++ b/rlpy/Domains/FlipBoard.py
@@ -1,4 +1,11 @@
 """Flipboard domain."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Tools import plt, id2vec
 from .Domain import Domain
 import numpy as np

--- a/rlpy/Domains/GridWorld.py
+++ b/rlpy/Domains/GridWorld.py
@@ -130,7 +130,8 @@ class GridWorld(Domain):
                s[0],
                'k>',
                markersize=20.0 - self.COLS)
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()
 
     def showLearning(self, representation):
         if self.valueFunction_fig is None:

--- a/rlpy/Domains/GridWorld.py
+++ b/rlpy/Domains/GridWorld.py
@@ -344,9 +344,9 @@ class GridWorld(Domain):
     def isTerminal(self, s=None):
         if s is None:
             s = self.state
-        if self.map[s[0], s[1]] == self.GOAL:
+        if self.map[int(s[0]), int(s[1])] == self.GOAL:
             return True
-        if self.map[s[0], s[1]] == self.PIT:
+        if self.map[int(s[0]), int(s[1])] == self.PIT:
             return True
         return False
 
@@ -385,8 +385,8 @@ class GridWorld(Domain):
         pa = np.array([self.possibleActions(sn) for sn in ns])
         # Make rewards
         r = np.ones((k, 1)) * self.STEP_REWARD
-        goal = self.map[ns[:, 0], ns[:, 1]] == self.GOAL
-        pit = self.map[ns[:, 0], ns[:, 1]] == self.PIT
+        goal = self.map[ns[:, 0].astype(np.int), ns[:, 1].astype(np.int)] == self.GOAL
+        pit = self.map[ns[:, 0].astype(np.int), ns[:, 1].astype(np.int)] == self.PIT
         r[goal] = self.GOAL_REWARD
         r[pit] = self.PIT_REWARD
         # Make terminals

--- a/rlpy/Domains/GridWorld.py
+++ b/rlpy/Domains/GridWorld.py
@@ -1,4 +1,7 @@
 """Gridworld Domain."""
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 from rlpy.Tools import plt, FONTSIZE, linearMap
 import numpy as np
 from .Domain import Domain
@@ -66,7 +69,7 @@ class GridWorld(Domain):
 
     actions_num = 4
     # Constants in the map
-    EMPTY, BLOCKED, START, GOAL, PIT, AGENT = range(6)
+    EMPTY, BLOCKED, START, GOAL, PIT, AGENT = list(range(6))
     #: Up, Down, Left, Right
     ACTIONS = np.array([[-1, 0], [+1, 0], [0, -1], [0, +1]])
     # directory of maps shipped with rlpy
@@ -161,8 +164,8 @@ class GridWorld(Domain):
                 units='y',
                 cmap='Actions',
                 scale_units="height",
-                scale=self.ROWS /
-                arrow_ratio,
+                scale=old_div(self.ROWS,
+                arrow_ratio),
                 width=-
                 1 *
                 ARROW_WIDTH)
@@ -179,8 +182,8 @@ class GridWorld(Domain):
                 units='y',
                 cmap='Actions',
                 scale_units="height",
-                scale=self.ROWS /
-                arrow_ratio,
+                scale=old_div(self.ROWS,
+                arrow_ratio),
                 width=-
                 1 *
                 ARROW_WIDTH)
@@ -197,8 +200,8 @@ class GridWorld(Domain):
                 units='x',
                 cmap='Actions',
                 scale_units="width",
-                scale=self.COLS /
-                arrow_ratio,
+                scale=old_div(self.COLS,
+                arrow_ratio),
                 width=ARROW_WIDTH)
             self.leftArrows_fig.set_clim(vmin=0, vmax=1)
             X = np.arange(self.ROWS)
@@ -213,8 +216,8 @@ class GridWorld(Domain):
                 units='x',
                 cmap='Actions',
                 scale_units="width",
-                scale=self.COLS /
-                arrow_ratio,
+                scale=old_div(self.COLS,
+                arrow_ratio),
                 width=ARROW_WIDTH)
             self.rightArrows_fig.set_clim(vmin=0, vmax=1)
             plt.show()
@@ -238,8 +241,8 @@ class GridWorld(Domain):
              self.ROWS,
              self.actions_num),
             dtype='uint8')
-        for r in xrange(self.ROWS):
-            for c in xrange(self.COLS):
+        for r in range(self.ROWS):
+            for c in range(self.COLS):
                 if self.map[r, c] == self.BLOCKED:
                     V[r, c] = 0
                 if self.map[r, c] == self.GOAL:
@@ -256,7 +259,7 @@ class GridWorld(Domain):
                     Mask[c, r, As] = False
                     arrowColors[c, r, bestA] = 1
 
-                    for i in xrange(len(As)):
+                    for i in range(len(As)):
                         a = As[i]
                         Q = Qs[i]
                         value = linearMap(
@@ -343,7 +346,7 @@ class GridWorld(Domain):
         if s is None:
             s = self.state
         possibleA = np.array([], np.uint8)
-        for a in xrange(self.actions_num):
+        for a in range(self.actions_num):
             ns = s + self.ACTIONS[a]
             if (
                     ns[0] < 0 or ns[0] == self.ROWS or

--- a/rlpy/Domains/GridWorld.py
+++ b/rlpy/Domains/GridWorld.py
@@ -1,5 +1,12 @@
 """Gridworld Domain."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 from rlpy.Tools import plt, FONTSIZE, linearMap

--- a/rlpy/Domains/HIVTreatment.py
+++ b/rlpy/Domains/HIVTreatment.py
@@ -1,4 +1,7 @@
 """HIV Treatment domain"""
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
 from .Domain import Domain
 import numpy as np
 from scipy.integrate import odeint
@@ -178,7 +181,7 @@ def dsdt(s, t, eps1, eps2):
     return np.array([dT1, dT2, dT1s, dT2s, dV, dE])
 
 try:
-    from HIVTreatment_dynamics import dsdt
+    from .HIVTreatment_dynamics import dsdt
 except Exception as e:
-    print e
-    print "Cython extension for HIVTreatment dynamics not available, expect slow runtime"
+    print(e)
+    print("Cython extension for HIVTreatment dynamics not available, expect slow runtime")

--- a/rlpy/Domains/HIVTreatment.py
+++ b/rlpy/Domains/HIVTreatment.py
@@ -130,10 +130,11 @@ class HIVTreatment(Domain):
             ax.set_xlabel("Days")
         for i in range(n):
             handles[i].set_ydata(self.episode_data[i])
-            ax = handles[i].get_axes()
+            ax = handles[i].axes
             ax.relim()
             ax.autoscale_view()
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()
 
 
 def dsdt(s, t, eps1, eps2):

--- a/rlpy/Domains/HIVTreatment.py
+++ b/rlpy/Domains/HIVTreatment.py
@@ -1,6 +1,10 @@
 """HIV Treatment domain"""
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from .Domain import Domain
 import numpy as np

--- a/rlpy/Domains/HelicopterHover.py
+++ b/rlpy/Domains/HelicopterHover.py
@@ -1,5 +1,6 @@
 """Helicopter hovering task."""
 
+from builtins import range
 from .Domain import Domain
 import numpy as np
 import rlpy.Tools.transformations as trans

--- a/rlpy/Domains/HelicopterHover.py
+++ b/rlpy/Domains/HelicopterHover.py
@@ -1,5 +1,13 @@
 """Helicopter hovering task."""
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from .Domain import Domain
 import numpy as np

--- a/rlpy/Domains/InfiniteTrackCartPole.py
+++ b/rlpy/Domains/InfiniteTrackCartPole.py
@@ -1,5 +1,7 @@
 """Pendulum base domain."""
+from __future__ import division
 
+from past.utils import old_div
 from .CartPoleBase import CartPoleBase, StateIndex
 import numpy as np
 from rlpy.Tools import plt
@@ -71,7 +73,7 @@ class InfTrackCartPole(CartPoleBase):
     __author__ = "Robert H. Klein"
 
     #: Default limits on theta
-    ANGLE_LIMITS = [-np.pi / 15.0, np.pi / 15.0]
+    ANGLE_LIMITS = [old_div(-np.pi, 15.0), old_div(np.pi, 15.0)]
     #: Default limits on pendulum rate
     ANGULAR_RATE_LIMITS = [-2.0, 2.0]
     #: m - Default limits on cart position (this state is ignored by the agent)
@@ -90,10 +92,10 @@ class InfTrackCartPole(CartPoleBase):
     # lies at half this distance)
     LENGTH = 1.0
     # m - Length of moment-arm to center of mass (= half the pendulum length)
-    MOMENT_ARM = LENGTH / 2.
+    MOMENT_ARM = old_div(LENGTH, 2.)
     # 1/kg - Used in dynamics computations, equal to 1 / (MASS_PEND +
     # MASS_CART)
-    _ALPHA_MASS = 1.0 / (MASS_CART + MASS_PEND)
+    _ALPHA_MASS = old_div(1.0, (MASS_CART + MASS_PEND))
     # Time between steps
     dt = 0.1
     # Newtons, N - Maximum noise possible, uniformly distributed
@@ -199,7 +201,7 @@ class InfCartPoleBalance(InfTrackCartPole):
     #: Reward received when the pendulum falls below the horizontal
     FELL_REWARD = -1
     #: Limit on theta (Note that this may affect your representation's discretization)
-    ANGLE_LIMITS = [-np.pi / 2.0, np.pi / 2.0]
+    ANGLE_LIMITS = [old_div(-np.pi, 2.0), old_div(np.pi, 2.0)]
     #: Limits on pendulum rate, per 1Link of Lagoudakis & Parr
     ANGULAR_RATE_LIMITS = [
         -2., 2.]  # NOTE that L+P's rate limits [-2,2] are actually unphysically slow, and the pendulum
@@ -231,7 +233,7 @@ class InfCartPoleBalance(InfTrackCartPole):
             s = self.state
         return (
             # per L & P 2003
-            not (-np.pi / 2.0 < s[StateIndex.THETA] < np.pi / 2.0)
+            not (old_div(-np.pi, 2.0) < s[StateIndex.THETA] < old_div(np.pi, 2.0))
         )
 
 
@@ -252,7 +254,7 @@ class InfCartPoleSwingUp(InfTrackCartPole):
     __author__ = "Robert H. Klein"
 
     #: Goal region for reward
-    GOAL_LIMITS = [-np.pi / 6, np.pi / 6]
+    GOAL_LIMITS = [old_div(-np.pi, 6), old_div(np.pi, 6)]
     #: Limits on theta
     ANGLE_LIMITS = [-np.pi, np.pi]
     #: Limits on pendulum rate

--- a/rlpy/Domains/InfiniteTrackCartPole.py
+++ b/rlpy/Domains/InfiniteTrackCartPole.py
@@ -1,6 +1,12 @@
 """Pendulum base domain."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .CartPoleBase import CartPoleBase, StateIndex
 import numpy as np

--- a/rlpy/Domains/IntruderMonitoring.py
+++ b/rlpy/Domains/IntruderMonitoring.py
@@ -228,6 +228,7 @@ class IntruderMonitoring(Domain):
         s = self.state
         # Draw the environment
         if self.domain_fig is None:
+            plt.figure("Domain")
             self.domain_fig = plt.imshow(
                 self.map,
                 cmap='IntruderMonitoring',
@@ -264,4 +265,5 @@ class IntruderMonitoring(Domain):
             alpha=.7,
             markeredgecolor='k',
             markeredgewidth=2)
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()

--- a/rlpy/Domains/IntruderMonitoring.py
+++ b/rlpy/Domains/IntruderMonitoring.py
@@ -1,6 +1,12 @@
 """Intruder monitoring task."""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Tools import plt, id2vec, bound_vec
 import numpy as np

--- a/rlpy/Domains/IntruderMonitoring.py
+++ b/rlpy/Domains/IntruderMonitoring.py
@@ -1,5 +1,7 @@
 """Intruder monitoring task."""
+from __future__ import print_function
 
+from builtins import range
 from rlpy.Tools import plt, id2vec, bound_vec
 import numpy as np
 from .Domain import Domain
@@ -65,7 +67,7 @@ class IntruderMonitoring(Domain):
     episodeCap = 100              # Episode Cap
 
     # Constants in the map
-    EMPTY, INTRUDER, AGENT, DANGER = xrange(4)
+    EMPTY, INTRUDER, AGENT, DANGER = range(4)
         #: Actions: Up, Down, Left, Right, Null
     ACTIONS_PER_AGENT = np.array([[-1, 0], [+1, 0], [0, -1], [0, +1], [0, 0], ])
 
@@ -139,7 +141,7 @@ class IntruderMonitoring(Domain):
         # IntruderPolicy()
         intruders = np.array(s[self.NUMBER_OF_AGENTS * 2:].reshape(-1, 2))
         actions = [self.IntruderPolicy(intruders[i])
-                   for i in xrange(self.NUMBER_OF_INTRUDERS)]
+                   for i in range(self.NUMBER_OF_INTRUDERS)]
         actions = self.ACTIONS_PER_AGENT[actions]
         intruders += actions
 
@@ -195,21 +197,21 @@ class IntruderMonitoring(Domain):
         return possibleActions
 
     def printDomain(self, s, a):
-        print '--------------'
+        print('--------------')
 
-        for i in xrange(0, self.NUMBER_OF_AGENTS):
+        for i in range(0, self.NUMBER_OF_AGENTS):
             s_a = s[i * 2:i * 2 + 2]
             aa = id2vec(a, self.ACTION_LIMITS)
             # print 'Agent {} X: {} Y: {}'.format(i,s_a[0],s_a[1])
-            print 'Agent {} Location: {} Action {}'.format(i, s_a, aa)
+            print('Agent {} Location: {} Action {}'.format(i, s_a, aa))
         offset = 2 * self.NUMBER_OF_AGENTS
-        for i in xrange(0, self.NUMBER_OF_INTRUDERS):
+        for i in range(0, self.NUMBER_OF_INTRUDERS):
             s_i = s[offset + i * 2:offset + i * 2 + 2]
             # print 'Intruder {} X: {} Y: {}'.format(i,s_i[0],s_i[1])
-            print 'Intruder', s_i
+            print('Intruder', s_i)
         r, ns, terminal = self.step(s, a)
 
-        print 'Reward ', r
+        print('Reward ', r)
 
     def IntruderPolicy(self, s_i):
         """

--- a/rlpy/Domains/MountainCar.py
+++ b/rlpy/Domains/MountainCar.py
@@ -1,5 +1,12 @@
 """Classic mountain car task."""
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Tools import plt, bound, fromAtoB
 from rlpy.Tools import lines
 from .Domain import Domain

--- a/rlpy/Domains/PST.py
+++ b/rlpy/Domains/PST.py
@@ -1,6 +1,12 @@
 """Persistent search and track mission domain."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from builtins import object
 from past.utils import old_div

--- a/rlpy/Domains/PST.py
+++ b/rlpy/Domains/PST.py
@@ -205,6 +205,7 @@ class PST(Domain):
     def showDomain(self, a=0):
         s = self.state
         if self.domain_fig is None:
+            plt.figure("Domain")
             self.domain_fig = plt.figure(
                 1, (UAVLocation.SIZE * self.dist_between_locations + 1, self.NUM_UAV + 1))
             plt.show()
@@ -382,7 +383,8 @@ class PST(Domain):
             if numHealthySurveil > 0:
                 self.location_rect_vis[
                     len(self.location_rect_vis) - 1].set_color('green')
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()
         sleep(0.5)
 
     def showLearning(self, representation):

--- a/rlpy/Domains/PST.py
+++ b/rlpy/Domains/PST.py
@@ -1,5 +1,9 @@
 """Persistent search and track mission domain."""
+from __future__ import division
 
+from builtins import range
+from builtins import object
+from past.utils import old_div
 from time import sleep
 from rlpy.Tools import plt, vec2id, mpatches, lines, id2vec
 from .Domain import Domain
@@ -192,10 +196,10 @@ class PST(Domain):
         self.comms_line = None
         self.dist_between_locations = self.RECT_GAP + self.LOCATION_WIDTH
         self.DimNames = []
-        [self.DimNames.append('UAV%d-loc' % i) for i in xrange(NUM_UAV)]
-        [self.DimNames.append('UAV%d-fuel' % i) for i in xrange(NUM_UAV)]
-        [self.DimNames.append('UAV%d-act' % i) for i in xrange(NUM_UAV)]
-        [self.DimNames.append('UAV%d-sen' % i) for i in xrange(NUM_UAV)]
+        [self.DimNames.append('UAV%d-loc' % i) for i in range(NUM_UAV)]
+        [self.DimNames.append('UAV%d-fuel' % i) for i in range(NUM_UAV)]
+        [self.DimNames.append('UAV%d-act' % i) for i in range(NUM_UAV)]
+        [self.DimNames.append('UAV%d-sen' % i) for i in range(NUM_UAV)]
         super(PST, self).__init__()
 
     def showDomain(self, a=0):
@@ -225,9 +229,9 @@ class PST(Domain):
         self.subplot_axes.yaxis.set_visible(False)
 
         # Assign coordinates of each possible uav location on figure
-        self.location_coord = [0.5 + (self.LOCATION_WIDTH / 2) +
+        self.location_coord = [0.5 + (old_div(self.LOCATION_WIDTH, 2)) +
                                (self.dist_between_locations) * i for i in range(UAVLocation.SIZE - 1)]
-        self.location_coord.append(crashLocationX + self.LOCATION_WIDTH / 2)
+        self.location_coord.append(crashLocationX + old_div(self.LOCATION_WIDTH, 2))
 
          # Create rectangular patches at each of those locations
         self.location_rect_vis = [mpatches.Rectangle(
@@ -370,7 +374,7 @@ class PST(Domain):
                 sStruct.sensor))
         # We have comms coverage: draw a line between comms states to show this
         if (any(sStruct.locations == UAVLocation.COMMS)):
-            for i in xrange(len(self.comms_line)):
+            for i in range(len(self.comms_line)):
                 self.comms_line[i].set_visible(True)
                 self.comms_line[i].set_color('black')
                 self.subplot_axes.add_line(self.comms_line[i])
@@ -397,10 +401,10 @@ class PST(Domain):
 
         # TODO - incorporate cost graph as in matlab.
         fuelBurnedBool = [(actionVector[i] == UAVAction.LOITER and (nsStruct.locations[i] == UAVLocation.REFUEL or nsStruct.locations[i] == UAVLocation.BASE))
-                          for i in xrange(self.NUM_UAV)]
+                          for i in range(self.NUM_UAV)]
         fuelBurnedBool = np.array(fuelBurnedBool) == 0.
         nsStruct.fuel = np.array([sStruct.fuel[i] - self.NOM_FUEL_BURN * fuelBurnedBool[i]
-                                  for i in xrange(self.NUM_UAV)])  # if fuel
+                                  for i in range(self.NUM_UAV)])  # if fuel
         self.fuelUnitsBurned = np.sum(fuelBurnedBool)
         distanceTraveled = np.sum(
             np.logical_and(
@@ -409,13 +413,13 @@ class PST(Domain):
 
         # Actuator failure transition
         randomFails = np.array([self.random_state.random_sample()
-                                for dummy in xrange(self.NUM_UAV)])
+                                for dummy in range(self.NUM_UAV)])
         randomFails = randomFails > self.P_ACT_FAIL
         nsStruct.actuator = np.logical_and(sStruct.actuator, randomFails)
 
         # Sensor failure transition
         randomFails = np.array([self.random_state.random_sample()
-                                for dummy in xrange(self.NUM_UAV)])
+                                for dummy in range(self.NUM_UAV)])
         randomFails = randomFails > self.P_SENSOR_FAIL
         nsStruct.sensor = np.logical_and(sStruct.sensor, randomFails)
 
@@ -619,7 +623,7 @@ class PST(Domain):
         )
 
 
-class UAVLocation:
+class UAVLocation(object):
 
     """
     Enumerated type for possible UAV Locations
@@ -632,7 +636,7 @@ class UAVLocation:
     SIZE = 4
 
 
-class StateStruct:
+class StateStruct(object):
 
     """
     Custom internal state structure
@@ -646,7 +650,7 @@ class StateStruct:
         self.sensor = sensor
 
 
-class ActuatorState:
+class ActuatorState(object):
 
     """
     Enumerated type for individual actuator state.
@@ -656,7 +660,7 @@ class ActuatorState:
     SIZE = 2
 
 
-class SensorState:
+class SensorState(object):
 
     """
     Enumerated type for individual sensor state.
@@ -669,7 +673,7 @@ class SensorState:
 # retreat, advance, loiter
 
 
-class UAVAction:
+class UAVAction(object):
 
     """
     Enumerated type for individual UAV actions.
@@ -681,7 +685,7 @@ class UAVAction:
 # NOTE: properties2StateVec assumes the order loc,fuel,actuator,sensor
 
 
-class UAVIndex:
+class UAVIndex(object):
 
     """
     Enumerated type for individual UAV Locations

--- a/rlpy/Domains/Pacman.py
+++ b/rlpy/Domains/Pacman.py
@@ -1,4 +1,7 @@
 """Pacman game domain."""
+from builtins import str
+from builtins import range
+from builtins import object
 from rlpy.Tools import __rlpy_location__
 from .Domain import Domain
 from .PacmanPackage import layout, pacman, game, ghostAgents

--- a/rlpy/Domains/Pacman.py
+++ b/rlpy/Domains/Pacman.py
@@ -1,4 +1,12 @@
 """Pacman game domain."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/rlpy/Domains/PacmanPackage/__init__.py
+++ b/rlpy/Domains/PacmanPackage/__init__.py
@@ -1,5 +1,11 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # When reinforcement module is imported, the following submodules will be
 # imported.
+from future import standard_library
+standard_library.install_aliases()
 __all__ = ["game",
            "util",
            "layout",

--- a/rlpy/Domains/PacmanPackage/analysis.py
+++ b/rlpy/Domains/PacmanPackage/analysis.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # analysis.py
 # -----------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -16,6 +18,7 @@
 # value iteration.
 
 
+from builtins import str
 def question2():
     answerDiscount = 0.9
     answerNoise = 0.2
@@ -69,8 +72,8 @@ def question6():
     # If not possible, return 'NOT POSSIBLE'
 
 if __name__ == '__main__':
-    print 'Answers to analysis questions:'
-    import analysis
+    print('Answers to analysis questions:')
+    from . import analysis
     for q in [q for q in dir(analysis) if q.startswith('question')]:
         response = getattr(analysis, q)()
-        print '  Question %s:\t%s' % (q, str(response))
+        print('  Question %s:\t%s' % (q, str(response)))

--- a/rlpy/Domains/PacmanPackage/analysis.py
+++ b/rlpy/Domains/PacmanPackage/analysis.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import division
 # analysis.py
 # -----------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -18,6 +20,8 @@ from __future__ import absolute_import
 # value iteration.
 
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 def question2():
     answerDiscount = 0.9

--- a/rlpy/Domains/PacmanPackage/crawler.py
+++ b/rlpy/Domains/PacmanPackage/crawler.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import absolute_import
 # crawler.py
 # ----------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,9 +11,12 @@
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
 #!/usr/bin/python
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import math
 from math import pi as PI
-import environment
+from . import environment
 
 
 class CrawlingRobotEnvironment(environment.Environment):
@@ -33,8 +38,8 @@ class CrawlingRobotEnvironment(environment.Environment):
         minArmAngle, maxArmAngle = self.crawlingRobot.getMinAndMaxArmAngles()
         minHandAngle, maxHandAngle = self.crawlingRobot.getMinAndMaxHandAngles(
         )
-        armIncrement = (maxArmAngle - minArmAngle) / (self.nArmStates - 1)
-        handIncrement = (maxHandAngle - minHandAngle) / (self.nHandStates - 1)
+        armIncrement = old_div((maxArmAngle - minArmAngle), (self.nArmStates - 1))
+        handIncrement = old_div((maxHandAngle - minHandAngle), (self.nHandStates - 1))
         self.armBuckets = [minArmAngle + (armIncrement * i)
                            for i in range(self.nArmStates)]
         self.handBuckets = [minHandAngle + (handIncrement * i)
@@ -125,8 +130,8 @@ class CrawlingRobotEnvironment(environment.Environment):
         # Also call self.crawlingRobot.setAngles()
         # to the initial arm and hand angle
 
-        armState = self.nArmStates / 2
-        handState = self.nHandStates / 2
+        armState = old_div(self.nArmStates, 2)
+        handState = old_div(self.nHandStates, 2)
         self.state = armState, handState
         self.crawlingRobot.setAngles(
             self.armBuckets[armState],
@@ -135,7 +140,7 @@ class CrawlingRobotEnvironment(environment.Environment):
             20, self.crawlingRobot.getRobotPosition()[0]]
 
 
-class CrawlingRobot:
+class CrawlingRobot(object):
 
     def setAngles(self, armAngle, handAngle):
         """
@@ -233,7 +238,7 @@ class CrawlingRobot:
         y = self.armLength * armSin + \
             self.handLength * handSin + self.robotHeight
         if y < 0:
-            return math.atan(-y / x)
+            return math.atan(old_div(-y, x))
         return 0.0
 
     # You shouldn't need methods below here
@@ -327,7 +332,7 @@ class CrawlingRobot:
  #       self.velAvg2 = g * self.velAvg2 + (1 - g) * velocity
         pos = self.positions[-1]
         velocity = pos - self.positions[-2]
-        vel2 = (pos - self.positions[0]) / len(self.positions)
+        vel2 = old_div((pos - self.positions[0]), len(self.positions))
         self.velAvg = .9 * self.velAvg + .1 * vel2
         velMsg = '100-step Avg Velocity: %.2f' % self.velAvg
 #        velMsg2 = '1000-step Avg Velocity: %.2f' % self.velAvg2
@@ -361,13 +366,13 @@ class CrawlingRobot:
 
         ## Arm and Hand Degrees ##
         self.armAngle = self.oldArmDegree = 0.0
-        self.handAngle = self.oldHandDegree = -PI / 6
+        self.handAngle = self.oldHandDegree = old_div(-PI, 6)
 
-        self.maxArmAngle = PI / 6
-        self.minArmAngle = -PI / 6
+        self.maxArmAngle = old_div(PI, 6)
+        self.minArmAngle = old_div(-PI, 6)
 
         self.maxHandAngle = 0
-        self.minHandAngle = -(5.0 / 6.0) * PI
+        self.minHandAngle = -(old_div(5.0, 6.0)) * PI
 
         ## Draw Ground ##
         self.totWidth = canvas.winfo_reqwidth()
@@ -406,5 +411,5 @@ class CrawlingRobot:
 
 
 if __name__ == '__main__':
-    from graphicsCrawlerDisplay import run
+    from .graphicsCrawlerDisplay import run
     run()

--- a/rlpy/Domains/PacmanPackage/crawler.py
+++ b/rlpy/Domains/PacmanPackage/crawler.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
 # crawler.py
 # ----------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +13,8 @@ from __future__ import absolute_import
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
 #!/usr/bin/python
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from builtins import object
 from past.utils import old_div

--- a/rlpy/Domains/PacmanPackage/environment.py
+++ b/rlpy/Domains/PacmanPackage/environment.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # environment.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +15,8 @@
 #!/usr/bin/python
 
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 class Environment(object):
 

--- a/rlpy/Domains/PacmanPackage/environment.py
+++ b/rlpy/Domains/PacmanPackage/environment.py
@@ -11,7 +11,8 @@
 #!/usr/bin/python
 
 
-class Environment:
+from builtins import object
+class Environment(object):
 
     def getCurrentState(self):
         """

--- a/rlpy/Domains/PacmanPackage/featureExtractors.py
+++ b/rlpy/Domains/PacmanPackage/featureExtractors.py
@@ -11,7 +11,12 @@
 "Feature extractors for Pacman game states"
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from builtins import object
 from .game import Directions, Actions

--- a/rlpy/Domains/PacmanPackage/featureExtractors.py
+++ b/rlpy/Domains/PacmanPackage/featureExtractors.py
@@ -9,12 +9,16 @@
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
 "Feature extractors for Pacman game states"
+from __future__ import division
+from __future__ import absolute_import
 
-from game import Directions, Actions
-import util
+from past.utils import old_div
+from builtins import object
+from .game import Directions, Actions
+from . import util
 
 
-class FeatureExtractor:
+class FeatureExtractor(object):
 
     def getFeatures(self, state, action):
         """
@@ -105,7 +109,7 @@ class SimpleExtractor(FeatureExtractor):
         if dist is not None:
             # make the distance a number less than one otherwise the update
             # will diverge wildly
-            features["closest-food"] = float(dist) / \
-                (walls.width * walls.height)
+            features["closest-food"] = old_div(float(dist), \
+                (walls.width * walls.height))
         features.divideAll(10.0)
         return features

--- a/rlpy/Domains/PacmanPackage/game.py
+++ b/rlpy/Domains/PacmanPackage/game.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # game.py
 # -------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -19,6 +20,8 @@ from __future__ import absolute_import
 # John DeNero (denero@cs.berkeley.edu) and Dan Klein (klein@cs.berkeley.edu).
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/sp09/pacman.html
 
+from builtins import dict
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str

--- a/rlpy/Domains/PacmanPackage/game.py
+++ b/rlpy/Domains/PacmanPackage/game.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # game.py
 # -------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -16,7 +19,13 @@
 # John DeNero (denero@cs.berkeley.edu) and Dan Klein (klein@cs.berkeley.edu).
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/sp09/pacman.html
 
-from util import *
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
+from .util import *
 import time
 import os
 import traceback
@@ -27,7 +36,7 @@ import sys
 #######################
 
 
-class Agent:
+class Agent(object):
 
     """
     An agent must define a getAction method, but may also define the
@@ -47,7 +56,7 @@ class Agent:
         raiseNotDefined()
 
 
-class Directions:
+class Directions(object):
     NORTH = 'North'
     SOUTH = 'South'
     EAST = 'East'
@@ -60,7 +69,7 @@ class Directions:
             WEST: SOUTH,
             STOP: STOP}
 
-    RIGHT = dict([(y, x) for x, y in LEFT.items()])
+    RIGHT = dict([(y, x) for x, y in list(LEFT.items())])
 
     REVERSE = {NORTH: SOUTH,
                SOUTH: NORTH,
@@ -69,7 +78,7 @@ class Directions:
                STOP: STOP}
 
 
-class Configuration:
+class Configuration(object):
 
     """
     A Configuration holds the (x,y) coordinate of a character, along with its
@@ -122,7 +131,7 @@ class Configuration:
         return Configuration((x + dx, y + dy), direction)
 
 
-class AgentState:
+class AgentState(object):
 
     """
     AgentStates hold the state of an agent (configuration, speed, scared, etc).
@@ -167,7 +176,7 @@ class AgentState:
         return self.configuration.getDirection()
 
 
-class Grid:
+class Grid(object):
 
     """
     A 2-dimensional array of objects backed by a list of lists.  Data is accessed
@@ -262,7 +271,7 @@ class Grid:
         return tuple(bits)
 
     def _cellIndexToPosition(self, index):
-        x = index / self.height
+        x = old_div(index, self.height)
         y = index % self.height
         return x, y
 
@@ -304,7 +313,7 @@ def reconstituteGrid(bitRep):
 ####################################
 
 
-class Actions:
+class Actions(object):
 
     """
     A collection of static methods for manipulating move actions.
@@ -316,7 +325,7 @@ class Actions:
                    Directions.WEST: (-1, 0),
                    Directions.STOP: (0, 0)}
 
-    _directionsAsList = _directions.items()
+    _directionsAsList = list(_directions.items())
 
     TOLERANCE = .001
 
@@ -394,7 +403,7 @@ class Actions:
     getSuccessor = staticmethod(getSuccessor)
 
 
-class GameStateData:
+class GameStateData(object):
 
     """
 
@@ -461,7 +470,7 @@ class GameStateData:
             try:
                 int(hash(state))
             except TypeError as e:
-                print e
+                print(e)
                 # hash(state)
         return (
             int((hash(tuple(self.agentStates)) + 13 * hash(self.food) + 113 *
@@ -552,7 +561,7 @@ except:
     _BOINC_ENABLED = False
 
 
-class Game:
+class Game(object):
 
     """
     The Game manages the control flow, soliciting actions from agents.
@@ -572,8 +581,8 @@ class Game:
         self.totalAgentTimes = [0 for agent in agents]
         self.totalAgentTimeWarnings = [0 for agent in agents]
         self.agentTimeout = False
-        import cStringIO
-        self.agentOutput = [cStringIO.StringIO() for agent in agents]
+        import io
+        self.agentOutput = [io.StringIO() for agent in agents]
 
     def getProgress(self):
         if self.gameOver:
@@ -596,7 +605,7 @@ class Game:
         if not self.muteAgents:
             return
         global OLD_STDOUT, OLD_STDERR
-        import cStringIO
+        import io
         OLD_STDOUT = sys.stdout
         OLD_STDERR = sys.stderr
         sys.stdout = self.agentOutput[agentIndex]
@@ -625,7 +634,7 @@ class Game:
                 self.mute(i)
                 # this is a null agent, meaning it failed to load
                 # the other team wins
-                print >>sys.stderr, "Agent %d failed to load" % i
+                print("Agent %d failed to load" % i, file=sys.stderr)
                 self.unmute()
                 self._agentCrash(i, quiet=True)
                 return
@@ -642,7 +651,7 @@ class Game:
                             time_taken = time.time() - start_time
                             self.totalAgentTimes[i] += time_taken
                         except TimeoutFunctionException:
-                            print >>sys.stderr, "Agent %d ran out of time on startup!" % i
+                            print("Agent %d ran out of time on startup!" % i, file=sys.stderr)
                             self.unmute()
                             self.agentTimeout = True
                             self._agentCrash(i, quiet=True)
@@ -704,7 +713,7 @@ class Game:
                             raise TimeoutFunctionException()
                         action = timed_func(observation)
                     except TimeoutFunctionException:
-                        print >>sys.stderr, "Agent %d timed out on a single move!" % agentIndex
+                        print("Agent %d timed out on a single move!" % agentIndex, file=sys.stderr)
                         self.agentTimeout = True
                         self._agentCrash(agentIndex, quiet=True)
                         self.unmute()
@@ -714,11 +723,11 @@ class Game:
 
                     if move_time > self.rules.getMoveWarningTime(agentIndex):
                         self.totalAgentTimeWarnings[agentIndex] += 1
-                        print >>sys.stderr, "Agent %d took too long to make a move! This is warning %d" % (
-                            agentIndex, self.totalAgentTimeWarnings[agentIndex])
+                        print("Agent %d took too long to make a move! This is warning %d" % (
+                            agentIndex, self.totalAgentTimeWarnings[agentIndex]), file=sys.stderr)
                         if self.totalAgentTimeWarnings[agentIndex] > self.rules.getMaxTimeWarnings(agentIndex):
-                            print >>sys.stderr, "Agent %d exceeded the maximum number of warnings: %d" % (
-                                agentIndex, self.totalAgentTimeWarnings[agentIndex])
+                            print("Agent %d exceeded the maximum number of warnings: %d" % (
+                                agentIndex, self.totalAgentTimeWarnings[agentIndex]), file=sys.stderr)
                             self.agentTimeout = True
                             self._agentCrash(agentIndex, quiet=True)
                             self.unmute()
@@ -728,8 +737,8 @@ class Game:
                     # print "Agent: %d, time: %f, total: %f" % (agentIndex,
                     # move_time, self.totalAgentTimes[agentIndex])
                     if self.totalAgentTimes[agentIndex] > self.rules.getMaxTotalTime(agentIndex):
-                        print >>sys.stderr, "Agent %d ran out of time! (time: %1.2f)" % (
-                            agentIndex, self.totalAgentTimes[agentIndex])
+                        print("Agent %d ran out of time! (time: %1.2f)" % (
+                            agentIndex, self.totalAgentTimes[agentIndex]), file=sys.stderr)
                         self.agentTimeout = True
                         self._agentCrash(agentIndex, quiet=True)
                         self.unmute()

--- a/rlpy/Domains/PacmanPackage/ghostAgents.py
+++ b/rlpy/Domains/PacmanPackage/ghostAgents.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
 # ghostAgents.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -10,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from past.utils import old_div
 from .game import Agent

--- a/rlpy/Domains/PacmanPackage/ghostAgents.py
+++ b/rlpy/Domains/PacmanPackage/ghostAgents.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import absolute_import
 # ghostAgents.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,12 +10,14 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from game import Agent
-from game import Actions
-from game import Directions
+from builtins import zip
+from past.utils import old_div
+from .game import Agent
+from .game import Actions
+from .game import Directions
 import random
-from util import manhattanDistance
-import util
+from .util import manhattanDistance
+from . import util
 
 
 class GhostAgent(Agent):
@@ -88,8 +92,8 @@ class DirectionalGhost(GhostAgent):
         # Construct distribution
         dist = util.Counter()
         for a in bestActions:
-            dist[a] = bestProb / len(bestActions)
+            dist[a] = old_div(bestProb, len(bestActions))
         for a in legalActions:
-            dist[a] += (1 - bestProb) / len(legalActions)
+            dist[a] += old_div((1 - bestProb), len(legalActions))
         dist.normalize()
         return dist

--- a/rlpy/Domains/PacmanPackage/grading.py
+++ b/rlpy/Domains/PacmanPackage/grading.py
@@ -11,7 +11,13 @@
 "Common code for autograders"
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import division
 
+from builtins import open
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import object
 import cgi

--- a/rlpy/Domains/PacmanPackage/grading.py
+++ b/rlpy/Domains/PacmanPackage/grading.py
@@ -9,17 +9,21 @@
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
 "Common code for autograders"
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import str
+from builtins import object
 import cgi
 import time
 import sys
 import traceback
 import pdb
 from collections import defaultdict
-import util
+from . import util
 
 
-class Grades:
+class Grades(object):
 
     "A data structure for project grades, along with formatting code to display them"
 
@@ -43,7 +47,7 @@ class Grades:
         self.prereqs = defaultdict(set)
 
         # print 'Autograder transcript for %s' % self.project
-        print 'Starting on %d-%d at %d:%02d:%02d' % self.start
+        print('Starting on %d-%d at %d:%02d:%02d' % self.start)
 
     def addPrereq(self, question, prereq):
         self.prereqs[question].add(prereq)
@@ -56,18 +60,17 @@ class Grades:
 
         completedQuestions = set([])
         for q in self.questions:
-            print '\nQuestion %s' % q
-            print '=' * (9 + len(q))
-            print
+            print('\nQuestion %s' % q)
+            print('=' * (9 + len(q)))
+            print()
             self.currentQuestion = q
 
             incompleted = self.prereqs[q].difference(completedQuestions)
             if len(incompleted) > 0:
                 prereq = incompleted.pop()
-                print \
-                    """*** NOTE: Make sure to complete Question %s before working on Question %s,
+                print("""*** NOTE: Make sure to complete Question %s before working on Question %s,
 *** because Question %s builds upon your answer for Question %s.
-""" % (prereq, q, q, prereq)
+""" % (prereq, q, q, prereq))
                 continue
 
             if self.mute:
@@ -89,17 +92,17 @@ class Grades:
             if self.points[q] >= self.maxes[q]:
                 completedQuestions.add(q)
 
-            print '\n### Question %s: %d/%d ###\n' % (q, self.points[q], self.maxes[q])
+            print('\n### Question %s: %d/%d ###\n' % (q, self.points[q], self.maxes[q]))
 
-        print '\nFinished at %d:%02d:%02d' % time.localtime()[3:6]
-        print "\nProvisional grades\n=================="
+        print('\nFinished at %d:%02d:%02d' % time.localtime()[3:6])
+        print("\nProvisional grades\n==================")
 
         for q in self.questions:
-            print 'Question %s: %d/%d' % (q, self.points[q], self.maxes[q])
-        print '------------------'
-        print 'Total: %d/%d' % (self.points.totalCount(), sum(self.maxes.values()))
+            print('Question %s: %d/%d' % (q, self.points[q], self.maxes[q]))
+        print('------------------')
+        print('Total: %d/%d' % (self.points.totalCount(), sum(self.maxes.values())))
         if bonusPic and self.points.totalCount() == 25:
-            print """
+            print("""
 
                      ALL HAIL GRANDPAC.
               LONG LIVE THE GHOSTBUSTING KING.
@@ -130,14 +133,14 @@ class Grades:
                 @@@@@@@@@@@@@@@@@@@@@@@@@@
                     @@@@@@@@@@@@@@@@@@
 
-"""
-        print """
+""")
+        print("""
 Your grades are NOT yet registered.  To register your grades you must
 submit your files to the edX website.  The grades obtained through the
 edX website are your final grades unless your submission was not in
 the spirit of the course,  such as if your submission simply hardcoded
 the answers to the tests.   We will screen for this after the deadline.
-"""
+""")
 
         if self.edxOutput:
             self.produceOutput()
@@ -256,14 +259,14 @@ the answers to the tests.   We will screen for this after the deadline.
                 # separately
             if self.mute:
                 util.unmutePrint()
-            print '*** ' + message
+            print('*** ' + message)
             if self.mute:
                 util.mutePrint()
             message = cgi.escape(message)
         self.messages[self.currentQuestion].append(message)
 
     def addMessageToEmail(self, message):
-        print "WARNING**** addMessageToEmail is deprecated %s" % message
+        print("WARNING**** addMessageToEmail is deprecated %s" % message)
         for line in message.split('\n'):
             pass
             # print '%%% ' + line + ' %%%'

--- a/rlpy/Domains/PacmanPackage/graphicsCrawlerDisplay.py
+++ b/rlpy/Domains/PacmanPackage/graphicsCrawlerDisplay.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # graphicsCrawlerDisplay.py
 # -------------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -21,6 +22,7 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import range

--- a/rlpy/Domains/PacmanPackage/graphicsCrawlerDisplay.py
+++ b/rlpy/Domains/PacmanPackage/graphicsCrawlerDisplay.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # graphicsCrawlerDisplay.py
 # -------------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -18,12 +21,17 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-import Tkinter
-import qlearningAgents
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from builtins import object
+from past.utils import old_div
+import tkinter
+from . import qlearningAgents
 import time
 import threading
 import sys
-import crawler
+from . import crawler
 #import pendulum
 import math
 from math import pi as PI
@@ -31,10 +39,10 @@ from math import pi as PI
 robotType = 'crawler'
 
 
-class Application:
+class Application(object):
 
     def sigmoid(self, x):
-        return 1.0 / (1.0 + 2.0 ** (-x))
+        return old_div(1.0, (1.0 + 2.0 ** (-x)))
 
     def incrementSpeed(self, inc):
         self.tickTime *= inc
@@ -90,65 +98,65 @@ class Application:
 #        self.setupSimulationButtons(win)
 
          ## Canvas ##
-        self.canvas = Tkinter.Canvas(root, height=200, width=1000)
+        self.canvas = tkinter.Canvas(root, height=200, width=1000)
         self.canvas.grid(row=2, columnspan=10)
 
     def setupAlphaButtonAndLabel(self, win):
-        self.alpha_minus = Tkinter.Button(win,
+        self.alpha_minus = tkinter.Button(win,
                                           text="-", command=(lambda: self.incrementAlpha(self.dec)))
         self.alpha_minus.grid(row=1, column=3, padx=10)
 
         self.alpha = self.sigmoid(self.al)
-        self.alpha_label = Tkinter.Label(
+        self.alpha_label = tkinter.Label(
             win, text='Learning Rate: %.3f' %
             (self.alpha))
         self.alpha_label.grid(row=1, column=4)
 
-        self.alpha_plus = Tkinter.Button(win,
+        self.alpha_plus = tkinter.Button(win,
                                          text="+", command=(lambda: self.incrementAlpha(self.inc)))
         self.alpha_plus.grid(row=1, column=5, padx=10)
 
     def setUpGammaButtonAndLabel(self, win):
-        self.gamma_minus = Tkinter.Button(win,
+        self.gamma_minus = tkinter.Button(win,
                                           text="-", command=(lambda: self.incrementGamma(self.dec)))
         self.gamma_minus.grid(row=1, column=0, padx=10)
 
         self.gamma = self.sigmoid(self.ga)
-        self.gamma_label = Tkinter.Label(
+        self.gamma_label = tkinter.Label(
             win, text='Discount: %.3f' %
             (self.gamma))
         self.gamma_label.grid(row=1, column=1)
 
-        self.gamma_plus = Tkinter.Button(win,
+        self.gamma_plus = tkinter.Button(win,
                                          text="+", command=(lambda: self.incrementGamma(self.inc)))
         self.gamma_plus.grid(row=1, column=2, padx=10)
 
     def setupEpsilonButtonAndLabel(self, win):
-        self.epsilon_minus = Tkinter.Button(win,
+        self.epsilon_minus = tkinter.Button(win,
                                             text="-", command=(lambda: self.incrementEpsilon(self.dec)))
         self.epsilon_minus.grid(row=0, column=3)
 
         self.epsilon = self.sigmoid(self.ep)
-        self.epsilon_label = Tkinter.Label(
+        self.epsilon_label = tkinter.Label(
             win, text='Epsilon: %.3f' %
             (self.epsilon))
         self.epsilon_label.grid(row=0, column=4)
 
-        self.epsilon_plus = Tkinter.Button(win,
+        self.epsilon_plus = tkinter.Button(win,
                                            text="+", command=(lambda: self.incrementEpsilon(self.inc)))
         self.epsilon_plus.grid(row=0, column=5)
 
     def setupSpeedButtonAndLabel(self, win):
-        self.speed_minus = Tkinter.Button(win,
+        self.speed_minus = tkinter.Button(win,
                                           text="-", command=(lambda: self.incrementSpeed(.5)))
         self.speed_minus.grid(row=0, column=0)
 
-        self.speed_label = Tkinter.Label(
+        self.speed_label = tkinter.Label(
             win, text='Step Delay: %.5f' %
             (self.tickTime))
         self.speed_label.grid(row=0, column=1)
 
-        self.speed_plus = Tkinter.Button(win,
+        self.speed_plus = tkinter.Button(win,
                                          text="+", command=(lambda: self.incrementSpeed(2)))
         self.speed_plus.grid(row=0, column=2)
 
@@ -216,7 +224,7 @@ class Application:
             self.robotEnvironment.reset()
             state = self.robotEnvironment.getCurrentState()
             actions = self.robotEnvironment.getPossibleActions(state)
-            print 'Reset!'
+            print('Reset!')
         action = self.learner.getAction(state)
         if action is None:
             raise 'None action returned: Code Not Complete'
@@ -242,23 +250,23 @@ class Application:
             self.canvas.create_line(x + length, y - length, x, y - length)
             self.canvas.create_line(x, y - length, x, y)
             self.animatePolicyBox = 1
-            self.canvas.create_text(x + length / 2, y + 10, text='angle')
-            self.canvas.create_text(x - 30, y - length / 2, text='velocity')
+            self.canvas.create_text(x + old_div(length, 2), y + 10, text='angle')
+            self.canvas.create_text(x - 30, y - old_div(length, 2), text='velocity')
             self.canvas.create_text(
                 x - 60,
-                y - length / 4,
+                y - old_div(length, 4),
                 text='Blue = kickLeft')
             self.canvas.create_text(
                 x - 60,
-                y - length / 4 + 20,
+                y - old_div(length, 4) + 20,
                 text='Red = kickRight')
             self.canvas.create_text(
                 x - 60,
-                y - length / 4 + 40,
+                y - old_div(length, 4) + 40,
                 text='White = doNothing')
 
-        angleDelta = (angleMax - angleMin) / 100
-        velDelta = (velMax - velMin) / 100
+        angleDelta = old_div((angleMax - angleMin), 100)
+        velDelta = old_div((velMax - velMin), 100)
         for i in range(100):
             angle = angleMin + i * angleDelta
 
@@ -280,8 +288,8 @@ class Application:
                         color = 'red'
                     elif argMax == 'doNothing':
                         color = 'white'
-                    dx = length / 100.0
-                    dy = length / 100.0
+                    dx = old_div(length, 100.0)
+                    dy = old_div(length, 100.0)
                     x0, y0 = x + i * dx, y - j * dy
                     self.canvas.create_rectangle(
                         x0,
@@ -299,7 +307,7 @@ class Application:
             minSleep = .01
             tm = max(minSleep, self.tickTime)
             time.sleep(tm)
-            self.stepsToSkip = int(tm / self.tickTime) - 1
+            self.stepsToSkip = int(old_div(tm, self.tickTime)) - 1
 
             if not self.running:
                 self.stopped = True
@@ -317,7 +325,7 @@ class Application:
 
 def run():
     global root
-    root = Tkinter.Tk()
+    root = tkinter.Tk()
     root.title('Crawler GUI')
     root.resizable(0, 0)
 

--- a/rlpy/Domains/PacmanPackage/graphicsDisplay.py
+++ b/rlpy/Domains/PacmanPackage/graphicsDisplay.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # graphicsDisplay.py
 # ------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,10 +11,15 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from graphicsUtils import *
+from builtins import map
+from builtins import zip
+from builtins import range
+from builtins import object
+from past.utils import old_div
+from .graphicsUtils import *
 import math
 import time
-from game import Directions
+from .game import Directions
 
 ###########################
 #  GRAPHICS DISPLAY CODE  #
@@ -24,7 +32,7 @@ from game import Directions
 DEFAULT_GRID_SIZE = 30.0
 INFO_PANE_HEIGHT = 35
 BACKGROUND_COLOR = formatColor(0, 0, 0)
-WALL_COLOR = formatColor(0.0 / 255.0, 51.0 / 255.0, 255.0 / 255.0)
+WALL_COLOR = formatColor(old_div(0.0, 255.0), old_div(51.0, 255.0), old_div(255.0, 255.0))
 INFO_PANE_COLOR = formatColor(.4, .4, 0)
 SCORE_COLOR = formatColor(.9, .9, .9)
 PACMAN_OUTLINE_WIDTH = 2
@@ -56,9 +64,9 @@ GHOST_SHAPE = [
 GHOST_SIZE = 0.65
 SCARED_COLOR = formatColor(1, 1, 1)
 
-GHOST_VEC_COLORS = map(colorToVector, GHOST_COLORS)
+GHOST_VEC_COLORS = list(map(colorToVector, GHOST_COLORS))
 
-PACMAN_COLOR = formatColor(255.0 / 255.0, 255.0 / 255.0, 61.0 / 255)
+PACMAN_COLOR = formatColor(old_div(255.0, 255.0), old_div(255.0, 255.0), old_div(61.0, 255))
 PACMAN_SCALE = 0.5
 #pacman_speed = 0.25
 
@@ -78,7 +86,7 @@ CAPSULE_SIZE = 0.25
 WALL_RADIUS = 0.15
 
 
-class InfoPane:
+class InfoPane(object):
 
     def __init__(self, layout, gridSize):
         self.gridSize = gridSize
@@ -123,7 +131,7 @@ class InfoPane:
 
         for i, d in enumerate(distances):
             t = text(
-                self.toScreen(self.width / 2 + self.width / 8 * i,
+                self.toScreen(old_div(self.width, 2) + self.width / 8 * i,
                               0),
                 GHOST_COLORS[i + 1],
                 d,
@@ -176,7 +184,7 @@ class InfoPane:
         pass
 
 
-class PacmanGraphics:
+class PacmanGraphics(object):
 
     def __init__(self, zoom=1.0, frameTime=0.0, capture=False):
         self.have_window = 0
@@ -287,7 +295,7 @@ class PacmanGraphics:
                 remove_from_screen(f)
 
     def removeAllCapsules(self):
-        for c in self.capsules.values():
+        for c in list(self.capsules.values()):
             remove_from_screen(c)
 
     def make_window(self, width, height):
@@ -325,7 +333,7 @@ class PacmanGraphics:
         pos = x - int(x) + y - int(y)
         width = 30 + 80 * math.sin(math.pi * pos)
 
-        delta = width / 2
+        delta = old_div(width, 2)
         if (direction == 'West'):
             endpoints = (180 + delta, 180 - delta)
         elif (direction == 'North'):
@@ -345,7 +353,7 @@ class PacmanGraphics:
 
     def animatePacman(self, pacman, prevPacman, image):
         if self.frameTime < 0:
-            print 'Press any key to step forward, "q" to play'
+            print('Press any key to step forward, "q" to play')
             keys = wait_for_keys()
             if 'q' in keys:
                 self.frameTime = 0.1
@@ -360,7 +368,7 @@ class PacmanGraphics:
                     frames + fy * (frames - i) / frames
                 self.movePacman(pos, self.getDirection(pacman), image)
                 refresh()
-                sleep(abs(self.frameTime) / frames)
+                sleep(old_div(abs(self.frameTime), frames))
         else:
             self.movePacman(
                 self.getPosition(pacman),
@@ -400,14 +408,14 @@ class PacmanGraphics:
         if dir == 'West':
             dx = -0.2
         leftEye = circle(
-            (screen_x + self.gridSize * GHOST_SIZE * (-0.3 + dx / 1.5),
-             screen_y - self.gridSize * GHOST_SIZE * (0.3 - dy / 1.5)),
+            (screen_x + self.gridSize * GHOST_SIZE * (-0.3 + old_div(dx, 1.5)),
+             screen_y - self.gridSize * GHOST_SIZE * (0.3 - old_div(dy, 1.5))),
             self.gridSize * GHOST_SIZE * 0.2,
             WHITE,
             WHITE)
         rightEye = circle(
-            (screen_x + self.gridSize * GHOST_SIZE * (0.3 + dx / 1.5),
-             screen_y - self.gridSize * GHOST_SIZE * (0.3 - dy / 1.5)),
+            (screen_x + self.gridSize * GHOST_SIZE * (0.3 + old_div(dx, 1.5)),
+             screen_y - self.gridSize * GHOST_SIZE * (0.3 - old_div(dy, 1.5))),
             self.gridSize * GHOST_SIZE * 0.2,
             WHITE,
             WHITE)
@@ -447,13 +455,13 @@ class PacmanGraphics:
             dx = -0.2
         moveCircle(
             eyes[0],
-            (screen_x + self.gridSize * GHOST_SIZE * (-0.3 + dx / 1.5),
-             screen_y - self.gridSize * GHOST_SIZE * (0.3 - dy / 1.5)),
+            (screen_x + self.gridSize * GHOST_SIZE * (-0.3 + old_div(dx, 1.5)),
+             screen_y - self.gridSize * GHOST_SIZE * (0.3 - old_div(dy, 1.5))),
             self.gridSize * GHOST_SIZE * 0.2)
         moveCircle(
             eyes[1],
-            (screen_x + self.gridSize * GHOST_SIZE * (0.3 + dx / 1.5),
-             screen_y - self.gridSize * GHOST_SIZE * (0.3 - dy / 1.5)),
+            (screen_x + self.gridSize * GHOST_SIZE * (0.3 + old_div(dx, 1.5)),
+             screen_y - self.gridSize * GHOST_SIZE * (0.3 - old_div(dy, 1.5))),
             self.gridSize * GHOST_SIZE * 0.2)
         moveCircle(
             eyes[2],
@@ -870,7 +878,7 @@ class PacmanGraphics:
     def updateDistributions(self, distributions):
         "Draws an agent's belief distributions"
         # copy all distributions so we don't change their state
-        distributions = map(lambda x: x.copy(), distributions)
+        distributions = [x.copy() for x in distributions]
         if self.distributionImages is None:
             self.drawDistributions(self.previousState)
         for x in range(len(self.distributionImages)):

--- a/rlpy/Domains/PacmanPackage/graphicsDisplay.py
+++ b/rlpy/Domains/PacmanPackage/graphicsDisplay.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # graphicsDisplay.py
 # ------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +12,9 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import map
 from builtins import zip
 from builtins import range

--- a/rlpy/Domains/PacmanPackage/graphicsGridworldDisplay.py
+++ b/rlpy/Domains/PacmanPackage/graphicsGridworldDisplay.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # graphicsGridworldDisplay.py
 # ---------------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +12,9 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/rlpy/Domains/PacmanPackage/graphicsGridworldDisplay.py
+++ b/rlpy/Domains/PacmanPackage/graphicsGridworldDisplay.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # graphicsGridworldDisplay.py
 # ---------------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,12 +11,16 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-import util
-from graphicsUtils import *
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
+from . import util
+from .graphicsUtils import *
 from functools import reduce
 
 
-class GraphicsGridworldDisplay:
+class GraphicsGridworldDisplay(object):
 
     def __init__(self, gridworld, size=120, speed=1.0):
         self.gridworld = gridworld
@@ -35,7 +42,7 @@ class GraphicsGridworldDisplay:
             values[state] = agent.getValue(state)
             policy[state] = agent.getPolicy(state)
         drawValues(self.gridworld, values, policy, currentState, message)
-        sleep(0.05 / self.speed)
+        sleep(old_div(0.05, self.speed))
 
     def displayNullValues(self, currentState=None, message=''):
         values = util.Counter()
@@ -46,7 +53,7 @@ class GraphicsGridworldDisplay:
             #policy[state] = agent.getPolicy(state)
         drawNullValues(self.gridworld, currentState, '')
         # drawValues(self.gridworld, values, policy, currentState, message)
-        sleep(0.05 / self.speed)
+        sleep(old_div(0.05, self.speed))
 
     def displayQValues(self, agent, currentState=None,
                        message='Agent Q-Values'):
@@ -56,7 +63,7 @@ class GraphicsGridworldDisplay:
             for action in self.gridworld.getPossibleActions(state):
                 qValues[(state, action)] = agent.getQValue(state, action)
         drawQValues(self.gridworld, qValues, currentState, message)
-        sleep(0.05 / self.speed)
+        sleep(old_div(0.05, self.speed))
 
 BACKGROUND_COLOR = formatColor(0, 0, 0)
 EDGE_COLOR = formatColor(1, 1, 1)
@@ -99,7 +106,7 @@ def drawNullValues(gridworld, currentState=None, message=''):
                 drawSquare(x, y, 0, 0, 0, None, None, True, False, isCurrent)
             else:
                 drawNullSquare(gridworld.grid, x, y, False, isExit, isCurrent)
-    pos = to_screen(((grid.width - 1.0) / 2.0, - 0.8))
+    pos = to_screen((old_div((grid.width - 1.0), 2.0), - 0.8))
     text(pos, TEXT_COLOR, message, "Courier", -32, "bold", "c")
 
 
@@ -138,7 +145,7 @@ def drawValues(gridworld, values, policy,
                     False,
                     isExit,
                     isCurrent)
-    pos = to_screen(((grid.width - 1.0) / 2.0, - 0.8))
+    pos = to_screen((old_div((grid.width - 1.0), 2.0), - 0.8))
     text(pos, TEXT_COLOR, message, "Courier", -32, "bold", "c")
 
 
@@ -199,7 +206,7 @@ def drawQValues(gridworld, qValues, currentState=None,
                     valStrings,
                     actions,
                     isCurrent)
-    pos = to_screen(((grid.width - 1.0) / 2.0, - 0.8))
+    pos = to_screen((old_div((grid.width - 1.0), 2.0), - 0.8))
     text(pos, TEXT_COLOR, message, "Courier", -32, "bold", "c")
 
 
@@ -359,7 +366,7 @@ def drawSquareQ(x, y, qVals, minVal, maxVal, valStrs, bestActions, isCurrent):
     w = (screen_x - 0.5 * GRID_SIZE + 5, screen_y)
     e = (screen_x + 0.5 * GRID_SIZE - 5, screen_y)
 
-    actions = qVals.keys()
+    actions = list(qVals.keys())
     for action in actions:
 
         wedge_color = getColor(qVals[action], minVal, maxVal)
@@ -468,7 +475,7 @@ def to_screen(point):
 
 def to_grid(point):
     (x, y) = point
-    x = int((y - MARGIN + GRID_SIZE * 0.5) / GRID_SIZE)
-    y = int((x - MARGIN + GRID_SIZE * 0.5) / GRID_SIZE)
-    print point, "-->", (x, y)
+    x = int(old_div((y - MARGIN + GRID_SIZE * 0.5), GRID_SIZE))
+    y = int(old_div((x - MARGIN + GRID_SIZE * 0.5), GRID_SIZE))
+    print(point, "-->", (x, y))
     return (x, y)

--- a/rlpy/Domains/PacmanPackage/graphicsUtils.py
+++ b/rlpy/Domains/PacmanPackage/graphicsUtils.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 # graphicsUtils.py
 # ----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -10,6 +12,8 @@ from __future__ import print_function
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import dict
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str

--- a/rlpy/Domains/PacmanPackage/graphicsUtils.py
+++ b/rlpy/Domains/PacmanPackage/graphicsUtils.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import print_function
 # graphicsUtils.py
 # ----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,13 +10,18 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys
 import math
 import random
 import string
 import time
 import types
-import Tkinter
+import tkinter
 
 _Windows = sys.platform == 'win32'  # True if on Win95/98/NT
 
@@ -35,7 +42,7 @@ def formatColor(r, g, b):
 
 def colorToVector(color):
     return (
-        map(lambda x: int(x, 16) / 256.0, [color[1:3], color[3:5], color[5:7]])
+        [old_div(int(x, 16), 256.0) for x in [color[1:3], color[3:5], color[5:7]]]
     )
 
 if _Windows:
@@ -71,14 +78,14 @@ def begin_graphics(width=640, height=480,
     _bg_color = color
 
     # Create the root window
-    _root_window = Tkinter.Tk()
+    _root_window = tkinter.Tk()
     _root_window.protocol('WM_DELETE_WINDOW', _destroy_window)
     _root_window.title(title or 'Graphics Window')
     _root_window.resizable(0, 0)
 
     # Create the canvas object
     try:
-        _canvas = Tkinter.Canvas(_root_window, width=width, height=height)
+        _canvas = tkinter.Canvas(_root_window, width=width, height=height)
         _canvas.pack()
         draw_background()
         _canvas.update()
@@ -164,7 +171,7 @@ def end_graphics():
             if _root_window is not None:
                 _root_window.destroy()
         except SystemExit as e:
-            print 'Ending graphics raised an exception:', e
+            print('Ending graphics raised an exception:', e)
     finally:
         _root_window = None
         _canvas = None
@@ -230,8 +237,8 @@ def image(pos, file="../../blueghost.gif"):
         _canvas.create_image(
             x,
             y,
-            image=Tkinter.PhotoImage(file=file),
-            anchor=Tkinter.NW)
+            image=tkinter.PhotoImage(file=file),
+            anchor=tkinter.NW)
     )
 
 
@@ -350,17 +357,17 @@ def _clear_keys(event=None):
     _got_release = None
 
 
-def keys_pressed(d_o_e=Tkinter.tkinter.dooneevent,
-                 d_w=Tkinter.tkinter.DONT_WAIT):
+def keys_pressed(d_o_e=lambda arg: _root_window.dooneevent(arg),
+                 d_w=tkinter._tkinter.DONT_WAIT):
     d_o_e(d_w)
     if _got_release:
         d_o_e(d_w)
-    return _keysdown.keys()
+    return list(_keysdown.keys())
 
 
 def keys_waiting():
     global _keyswaiting
-    keys = _keyswaiting.keys()
+    keys = list(_keyswaiting.keys())
     _keyswaiting = {}
     return keys
 
@@ -376,8 +383,8 @@ def wait_for_keys():
 
 
 def remove_from_screen(x,
-                       d_o_e=Tkinter.tkinter.dooneevent,
-                       d_w=Tkinter.tkinter.DONT_WAIT):
+                       d_o_e=lambda arg: _root_window.dooneevent(arg),
+                       d_w=tkinter._tkinter.DONT_WAIT):
     _canvas.delete(x)
     d_o_e(d_w)
 
@@ -390,8 +397,8 @@ def _adjust_coords(coord_list, x, y):
 
 
 def move_to(object, x, y=None,
-            d_o_e=Tkinter.tkinter.dooneevent,
-            d_w=Tkinter.tkinter.DONT_WAIT):
+            d_o_e=lambda arg: _root_window.dooneevent(arg),
+            d_w=tkinter._tkinter.DONT_WAIT):
     if y is None:
         try:
             x, y = x
@@ -415,8 +422,8 @@ def move_to(object, x, y=None,
 
 
 def move_by(object, x, y=None,
-            d_o_e=Tkinter.tkinter.dooneevent,
-            d_w=Tkinter.tkinter.DONT_WAIT, lift=False):
+            d_o_e=lambda arg: _root_window.dooneevent(arg),
+            d_w=tkinter._tkinter.DONT_WAIT, lift=False):
     if y is None:
         try:
             x, y = x

--- a/rlpy/Domains/PacmanPackage/gridworld.py
+++ b/rlpy/Domains/PacmanPackage/gridworld.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # gridworld.py
 # ------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/rlpy/Domains/PacmanPackage/gridworld.py
+++ b/rlpy/Domains/PacmanPackage/gridworld.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # gridworld.py
 # ------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,11 +11,15 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import random
 import sys
-import mdp
-import environment
-import util
+from . import mdp
+from . import environment
+from . import util
 import optparse
 
 
@@ -143,8 +150,8 @@ class Gridworld(mdp.MarkovDecisionProcess):
                 successors.append((southState, 1 - self.noise))
 
             massLeft = self.noise
-            successors.append((westState, massLeft / 2.0))
-            successors.append((eastState, massLeft / 2.0))
+            successors.append((westState, old_div(massLeft, 2.0)))
+            successors.append((eastState, old_div(massLeft, 2.0)))
 
         if action == 'west' or action == 'east':
             if action == 'west':
@@ -153,8 +160,8 @@ class Gridworld(mdp.MarkovDecisionProcess):
                 successors.append((eastState, 1 - self.noise))
 
             massLeft = self.noise
-            successors.append((northState, massLeft / 2.0))
-            successors.append((southState, massLeft / 2.0))
+            successors.append((northState, old_div(massLeft, 2.0)))
+            successors.append((southState, old_div(massLeft, 2.0)))
 
         successors = self.__aggregate(successors)
 
@@ -165,7 +172,7 @@ class Gridworld(mdp.MarkovDecisionProcess):
         for state, prob in statesAndProbs:
             counter[state] += prob
         newStatesAndProbs = []
-        for state, prob in counter.items():
+        for state, prob in list(counter.items()):
             newStatesAndProbs.append((state, prob))
         return newStatesAndProbs
 
@@ -216,7 +223,7 @@ class GridworldEnvironment(environment.Environment):
         self.state = self.gridWorld.getStartState()
 
 
-class Grid:
+class Grid(object):
 
     """
     A 2-dimensional array of immutables backed by a list of lists.  Data is accessed
@@ -332,7 +339,7 @@ def getUserAction(state, actionFunction):
 
     Used for debugging and lecture demos.
     """
-    import graphicsUtils
+    from . import graphicsUtils
     action = None
     while True:
         keys = graphicsUtils.wait_for_keys()
@@ -356,7 +363,7 @@ def getUserAction(state, actionFunction):
 
 
 def printString(x):
-    print x
+    print(x)
 
 
 def runEpisode(agent, environment, discount, decision,
@@ -459,7 +466,7 @@ def parseOptions():
     opts, args = optParser.parse_args()
 
     if opts.manual and opts.agent != 'q':
-        print '## Disabling Agents in Manual Mode (-m) ##'
+        print('## Disabling Agents in Manual Mode (-m) ##')
         opts.agent = None
 
     # MANAGE CONFLICTS
@@ -482,7 +489,7 @@ if __name__ == '__main__':
     # GET THE GRIDWORLD
     ###########################
 
-    import gridworld
+    from . import gridworld
     mdpFunction = getattr(gridworld, "get" + opts.grid)
     mdp = mdpFunction()
     mdp.setLivingReward(opts.livingReward)
@@ -492,10 +499,10 @@ if __name__ == '__main__':
     ###########################
     # GET THE DISPLAY ADAPTER
     ###########################
-    import textGridworldDisplay
+    from . import textGridworldDisplay
     display = textGridworldDisplay.TextGridworldDisplay(mdp)
     if not opts.textDisplay:
-        import graphicsGridworldDisplay
+        from . import graphicsGridworldDisplay
         display = graphicsGridworldDisplay.GraphicsGridworldDisplay(
             mdp,
             opts.gridSize,
@@ -509,8 +516,8 @@ if __name__ == '__main__':
     # GET THE AGENT
     ###########################
 
-    import valueIterationAgents
-    import qlearningAgents
+    from . import valueIterationAgents
+    from . import qlearningAgents
     a = None
     if opts.agent == 'value':
         a = valueIterationAgents.ValueIterationAgent(
@@ -532,7 +539,7 @@ if __name__ == '__main__':
         if opts.episodes == 0:
             opts.episodes = 10
 
-        class RandomAgent:
+        class RandomAgent(object):
 
             def getAction(self, state):
                 return random.choice(mdp.getPossibleActions(state))
@@ -624,18 +631,18 @@ if __name__ == '__main__':
 
     # RUN EPISODES
     if opts.episodes > 0:
-        print
-        print "RUNNING", opts.episodes, "EPISODES"
-        print
+        print()
+        print("RUNNING", opts.episodes, "EPISODES")
+        print()
     returns = 0
     for episode in range(1, opts.episodes + 1):
         returns += runEpisode(a, env, opts.discount, decisionCallback,
                               displayCallback, messageCallback, pauseCallback, episode)
     if opts.episodes > 0:
-        print
-        print "AVERAGE RETURNS FROM START STATE: " + str((returns + 0.0) / opts.episodes)
-        print
-        print
+        print()
+        print("AVERAGE RETURNS FROM START STATE: " + str(old_div((returns + 0.0), opts.episodes)))
+        print()
+        print()
 
     # DISPLAY POST-LEARNING VALUES / Q-VALUES
     if opts.agent == 'q' and not opts.manual:

--- a/rlpy/Domains/PacmanPackage/keyboardAgents.py
+++ b/rlpy/Domains/PacmanPackage/keyboardAgents.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # keyboardAgents.py
 # -----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,8 +9,8 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from game import Agent
-from game import Directions
+from .game import Agent
+from .game import Directions
 import random
 
 
@@ -32,8 +33,8 @@ class KeyboardAgent(Agent):
         self.keys = []
 
     def getAction(self, state):
-        from graphicsUtils import keys_waiting
-        from graphicsUtils import keys_pressed
+        from .graphicsUtils import keys_waiting
+        from .graphicsUtils import keys_pressed
         keys = keys_waiting() + keys_pressed()
         if keys != []:
             self.keys = keys

--- a/rlpy/Domains/PacmanPackage/keyboardAgents.py
+++ b/rlpy/Domains/PacmanPackage/keyboardAgents.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 # keyboardAgents.py
 # -----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from .game import Agent
 from .game import Directions
 import random

--- a/rlpy/Domains/PacmanPackage/layout.py
+++ b/rlpy/Domains/PacmanPackage/layout.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # layout.py
 # ---------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,8 +9,11 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from util import manhattanDistance
-from game import Grid
+from builtins import zip
+from builtins import range
+from builtins import object
+from .util import manhattanDistance
+from .game import Grid
 import os
 import random
 from functools import reduce
@@ -17,7 +21,7 @@ from functools import reduce
 VISIBILITY_MATRIX_CACHE = {}
 
 
-class Layout:
+class Layout(object):
 
     """
     A Layout manages the static information about the game board.
@@ -41,7 +45,7 @@ class Layout:
     def initializeVisibilityMatrix(self):
         global VISIBILITY_MATRIX_CACHE
         if reduce(str.__add__, self.layoutText) not in VISIBILITY_MATRIX_CACHE:
-            from game import Directions
+            from .game import Directions
             vecs = [(-0.5, 0), (0.5, 0), (0, -0.5), (0, 0.5)]
             dirs = [
                 Directions.NORTH,
@@ -76,11 +80,11 @@ class Layout:
         return self.walls[x][col]
 
     def getRandomLegalPosition(self):
-        x = random.choice(range(self.width))
-        y = random.choice(range(self.height))
+        x = random.choice(list(range(self.width)))
+        y = random.choice(list(range(self.height)))
         while self.isWall((x, y)):
-            x = random.choice(range(self.width))
-            y = random.choice(range(self.height))
+            x = random.choice(list(range(self.width)))
+            y = random.choice(list(range(self.height)))
         return (x, y)
 
     def getRandomCorner(self):

--- a/rlpy/Domains/PacmanPackage/layout.py
+++ b/rlpy/Domains/PacmanPackage/layout.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 # layout.py
 # ---------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +12,10 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import open
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from builtins import range
 from builtins import object

--- a/rlpy/Domains/PacmanPackage/learningAgents.py
+++ b/rlpy/Domains/PacmanPackage/learningAgents.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # learningAgents.py
 # -----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,10 +11,11 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from game import Directions, Agent, Actions
+from past.utils import old_div
+from .game import Directions, Agent, Actions
 
 import random
-import util
+from . import util
 import time
 
 
@@ -223,7 +227,7 @@ class ReinforcementAgent(ValueEstimationAgent):
     def registerInitialState(self, state):
         self.startEpisode()
         if self.episodesSoFar == 0:
-            print 'Beginning %d episodes of Training' % (self.numTraining)
+            print('Beginning %d episodes of Training' % (self.numTraining))
 
     def final(self, state):
         """
@@ -246,25 +250,25 @@ class ReinforcementAgent(ValueEstimationAgent):
 
         NUM_EPS_UPDATE = 100
         if self.episodesSoFar % NUM_EPS_UPDATE == 0:
-            print 'Reinforcement Learning Status:'
-            windowAvg = self.lastWindowAccumRewards / float(NUM_EPS_UPDATE)
+            print('Reinforcement Learning Status:')
+            windowAvg = old_div(self.lastWindowAccumRewards, float(NUM_EPS_UPDATE))
             if self.episodesSoFar <= self.numTraining:
-                trainAvg = self.accumTrainRewards / float(self.episodesSoFar)
-                print '\tCompleted %d out of %d training episodes' % (
-                    self.episodesSoFar, self.numTraining)
-                print '\tAverage Rewards over all training: %.2f' % (
-                    trainAvg)
+                trainAvg = old_div(self.accumTrainRewards, float(self.episodesSoFar))
+                print('\tCompleted %d out of %d training episodes' % (
+                    self.episodesSoFar, self.numTraining))
+                print('\tAverage Rewards over all training: %.2f' % (
+                    trainAvg))
             else:
-                testAvg = float(self.accumTestRewards) / \
-                    (self.episodesSoFar - self.numTraining)
-                print '\tCompleted %d test episodes' % (self.episodesSoFar - self.numTraining)
-                print '\tAverage Rewards over testing: %.2f' % testAvg
-            print '\tAverage Rewards for last %d episodes: %.2f' % (
-                NUM_EPS_UPDATE, windowAvg)
-            print '\tEpisode took %.2f seconds' % (time.time() - self.episodeStartTime)
+                testAvg = old_div(float(self.accumTestRewards), \
+                    (self.episodesSoFar - self.numTraining))
+                print('\tCompleted %d test episodes' % (self.episodesSoFar - self.numTraining))
+                print('\tAverage Rewards over testing: %.2f' % testAvg)
+            print('\tAverage Rewards for last %d episodes: %.2f' % (
+                NUM_EPS_UPDATE, windowAvg))
+            print('\tEpisode took %.2f seconds' % (time.time() - self.episodeStartTime))
             self.lastWindowAccumRewards = 0.0
             self.episodeStartTime = time.time()
 
         if self.episodesSoFar == self.numTraining:
             msg = 'Training Done (turning off epsilon and alpha)'
-            print '%s\n%s' % (msg, '-' * len(msg))
+            print('%s\n%s' % (msg, '-' * len(msg)))

--- a/rlpy/Domains/PacmanPackage/learningAgents.py
+++ b/rlpy/Domains/PacmanPackage/learningAgents.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # learningAgents.py
 # -----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +12,9 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .game import Directions, Agent, Actions
 

--- a/rlpy/Domains/PacmanPackage/mdp.py
+++ b/rlpy/Domains/PacmanPackage/mdp.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # mdp.py
 # ------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,6 +12,8 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 import random
 

--- a/rlpy/Domains/PacmanPackage/mdp.py
+++ b/rlpy/Domains/PacmanPackage/mdp.py
@@ -8,10 +8,11 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import object
 import random
 
 
-class MarkovDecisionProcess:
+class MarkovDecisionProcess(object):
 
     def getStates(self):
         """

--- a/rlpy/Domains/PacmanPackage/pacman.py
+++ b/rlpy/Domains/PacmanPackage/pacman.py
@@ -38,6 +38,10 @@ The keys are 'a', 's', 'd', and 'w' to move (or arrow keys).  Have fun!
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import dict
+from builtins import open
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str

--- a/rlpy/Domains/PacmanPackage/pacman.py
+++ b/rlpy/Domains/PacmanPackage/pacman.py
@@ -35,14 +35,23 @@ code to run a game.  This file is divided into three sections:
 To play your first game, type 'python pacman.py' from the command line.
 The keys are 'a', 's', 'd', and 'w' to move (or arrow keys).  Have fun!
 """
-from game import GameStateData
-from game import Game
-from game import Directions
-from game import Actions
-from util import nearestPoint
-from util import manhattanDistance
-import util
-import layout
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
+from .game import GameStateData
+from .game import Game
+from .game import Directions
+from .game import Actions
+from .util import nearestPoint
+from .util import manhattanDistance
+from . import util
+from . import layout
 import sys
 import types
 import time
@@ -54,7 +63,7 @@ import os
 ###################################################
 
 
-class GameState:
+class GameState(object):
 
     """
     A GameState specifies the full game state, including the food, capsules,
@@ -272,7 +281,7 @@ COLLISION_TOLERANCE = 0.7  # How close ghosts must be to Pacman to kill
 TIME_PENALTY = 1  # Number of points lost each round
 
 
-class ClassicGameRules:
+class ClassicGameRules(object):
 
     """
     These game rules manage the control flow of a game, deciding when
@@ -304,22 +313,22 @@ class ClassicGameRules:
 
     def win(self, state, game):
         if not self.quiet:
-            print "Pacman emerges victorious! Score: %d" % state.data.score
+            print("Pacman emerges victorious! Score: %d" % state.data.score)
         game.gameOver = True
 
     def lose(self, state, game):
         if not self.quiet:
-            print "Pacman died! Score: %d" % state.data.score
+            print("Pacman died! Score: %d" % state.data.score)
         game.gameOver = True
 
     def getProgress(self, game):
-        return float(game.state.getNumFood()) / self.initialState.getNumFood()
+        return old_div(float(game.state.getNumFood()), self.initialState.getNumFood())
 
     def agentCrash(self, game, agentIndex):
         if agentIndex == 0:
-            print "Pacman crashed"
+            print("Pacman crashed")
         else:
-            print "A ghost crashed"
+            print("A ghost crashed")
 
     def getMaxTotalTime(self, agentIndex):
         return self.timeout
@@ -337,7 +346,7 @@ class ClassicGameRules:
         return 0
 
 
-class PacmanRules:
+class PacmanRules(object):
 
     """
     These functions govern how pacman interacts with his environment under
@@ -402,7 +411,7 @@ class PacmanRules:
     consume = staticmethod(consume)
 
 
-class GhostRules:
+class GhostRules(object):
 
     """
     These functions dictate how ghosts interact with their environment.
@@ -608,14 +617,14 @@ def readCommand(argv):
 
     # Choose a display format
     if options.quietGraphics:
-        import textDisplay
+        from . import textDisplay
         args['display'] = textDisplay.NullGraphics()
     elif options.textGraphics:
-        import textDisplay
+        from . import textDisplay
         textDisplay.SLEEP_TIME = options.frameTime
         args['display'] = textDisplay.PacmanGraphics()
     else:
-        import graphicsDisplay
+        from . import graphicsDisplay
         args['display'] = graphicsDisplay.PacmanGraphics(
             options.zoom,
             frameTime=options.frameTime)
@@ -627,11 +636,11 @@ def readCommand(argv):
     # Special case: recorded games don't use the runGames method or args
     # structure
     if options.gameToReplay is not None:
-        print 'Replaying recorded game %s.' % options.gameToReplay
-        import cPickle
+        print('Replaying recorded game %s.' % options.gameToReplay)
+        import pickle
         f = open(options.gameToReplay)
         try:
-            recorded = cPickle.load(f)
+            recorded = pickle.load(f)
         finally:
             f.close()
         recorded['display'] = args['display']
@@ -674,8 +683,8 @@ def loadAgent(pacman, nographics):
 
 
 def replayGame(layout, actions, display):
-    import pacmanAgents
-    import ghostAgents
+    from . import pacmanAgents
+    from . import ghostAgents
     rules = ClassicGameRules()
     agents = [pacmanAgents.GreedyAgent()] + [ghostAgents.RandomGhost(i + 1)
                                              for i in range(layout.getNumGhosts())]
@@ -706,7 +715,7 @@ def runGames(layout, pacman, ghosts, display, numGames, record,
         beQuiet = i < numTraining
         if beQuiet:
                 # Suppress output and graphics
-            import textDisplay
+            from . import textDisplay
             gameDisplay = textDisplay.NullGraphics()
             rules.quiet = True
         else:
@@ -725,23 +734,23 @@ def runGames(layout, pacman, ghosts, display, numGames, record,
 
         if record:
             import time
-            import cPickle
+            import pickle
             fname = (
                 'recorded-game-%d' %
                 (i + 1)) + '-'.join([str(t) for t in time.localtime()[1:6]])
             f = file(fname, 'w')
             components = {'layout': layout, 'actions': game.moveHistory}
-            cPickle.dump(components, f)
+            pickle.dump(components, f)
             f.close()
 
     if (numGames - numTraining) > 0:
         scores = [game.state.getScore() for game in games]
         wins = [game.state.isWin() for game in games]
-        winRate = wins.count(True) / float(len(wins))
-        print 'Average Score:', sum(scores) / float(len(scores))
-        print 'Scores:       ', ', '.join([str(score) for score in scores])
-        print 'Win Rate:      %d/%d (%.2f)' % (wins.count(True), len(wins), winRate)
-        print 'Record:       ', ', '.join([['Loss', 'Win'][int(w)] for w in wins])
+        winRate = old_div(wins.count(True), float(len(wins)))
+        print('Average Score:', old_div(sum(scores), float(len(scores))))
+        print('Scores:       ', ', '.join([str(score) for score in scores]))
+        print('Win Rate:      %d/%d (%.2f)' % (wins.count(True), len(wins), winRate))
+        print('Record:       ', ', '.join([['Loss', 'Win'][int(w)] for w in wins]))
 
     return games
 

--- a/rlpy/Domains/PacmanPackage/pacmanAgents.py
+++ b/rlpy/Domains/PacmanPackage/pacmanAgents.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # pacmanAgents.py
 # ---------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,11 +9,11 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from pacman import Directions
-from game import Agent
+from .pacman import Directions
+from .game import Agent
 import random
-import game
-import util
+from . import game
+from . import util
 
 
 class LeftTurnAgent(game.Agent):

--- a/rlpy/Domains/PacmanPackage/pacmanAgents.py
+++ b/rlpy/Domains/PacmanPackage/pacmanAgents.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 # pacmanAgents.py
 # ---------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from .pacman import Directions
 from .game import Agent
 import random

--- a/rlpy/Domains/PacmanPackage/projectParams.py
+++ b/rlpy/Domains/PacmanPackage/projectParams.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # projectParams.py
 # ----------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,6 +12,8 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 STUDENT_CODE_DEFAULT = 'analysis.py,qlearningAgents.py,valueIterationAgents.py'
 PROJECT_TEST_CLASSES = 'reinforcementTestClasses.py'
 PROJECT_NAME = 'Project 3: Reinforcement learning'

--- a/rlpy/Domains/PacmanPackage/qlearningAgents.py
+++ b/rlpy/Domains/PacmanPackage/qlearningAgents.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 # qlearningAgents.py
 # ------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from .game import *
 from .learningAgents import ReinforcementAgent
 from .featureExtractors import *

--- a/rlpy/Domains/PacmanPackage/qlearningAgents.py
+++ b/rlpy/Domains/PacmanPackage/qlearningAgents.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # qlearningAgents.py
 # ------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,12 +9,12 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-from game import *
-from learningAgents import ReinforcementAgent
-from featureExtractors import *
+from .game import *
+from .learningAgents import ReinforcementAgent
+from .featureExtractors import *
 
 import random
-import util
+from . import util
 import math
 
 

--- a/rlpy/Domains/PacmanPackage/reinforcementTestClasses.py
+++ b/rlpy/Domains/PacmanPackage/reinforcementTestClasses.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import absolute_import
 # reinforcementTestClasses.py
 # ---------------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,18 +10,22 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-import testClasses
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from . import testClasses
 import random
 import math
 import traceback
 import sys
 import os
-import layout
-import textDisplay
-import pacman
-import gridworld
+from . import layout
+from . import textDisplay
+from . import pacman
+from . import gridworld
 import time
-from util import Counter, TimeoutFunction, FixedRandom
+from .util import Counter, TimeoutFunction, FixedRandom
 from collections import defaultdict
 from pprint import PrettyPrinter
 from hashlib import sha1
@@ -27,7 +33,7 @@ from functools import reduce
 pp = PrettyPrinter()
 VERBOSE = False
 
-import gridworld
+from . import gridworld
 
 LIVINGREWARD = -0.1
 NOISE = 0.2
@@ -45,8 +51,8 @@ class ValueIterationTest(testClasses.TestCase):
         if 'livingReward' in testDict:
             self.grid.setLivingReward(float(testDict['livingReward']))
         maxPreIterations = 10
-        self.numsIterationsForDisplay = range(
-            min(iterations, maxPreIterations))
+        self.numsIterationsForDisplay = list(range(
+            min(iterations, maxPreIterations)))
         self.testOutFile = testDict['test_out_file']
         if maxPreIterations < iterations:
             self.numsIterationsForDisplay.append(iterations)
@@ -275,8 +281,8 @@ class ApproximateQLearningTest(testClasses.TestCase):
             'alpha': self.learningRate}
         numExperiences = int(testDict['numExperiences'])
         maxPreExperiences = 10
-        self.numsExperiencesForDisplay = range(
-            min(numExperiences, maxPreExperiences))
+        self.numsExperiencesForDisplay = list(range(
+            min(numExperiences, maxPreExperiences)))
         self.testOutFile = testDict['test_out_file']
         if maxPreExperiences < numExperiences:
             self.numsExperiencesForDisplay.append(numExperiences)
@@ -364,8 +370,7 @@ class ApproximateQLearningTest(testClasses.TestCase):
             extractor=self.extractor,
             **self.opts)
         states = sorted(
-            filter(lambda state: len(self.grid.getPossibleActions(state)) > 0,
-                   self.grid.getStates()))
+            [state for state in self.grid.getStates() if len(self.grid.getPossibleActions(state)) > 0])
         randObj = FixedRandom().random
         # choose a random start state and a random possible action from that state
         # get the next state and reward from the transition function
@@ -469,8 +474,8 @@ class QLearningTest(testClasses.TestCase):
             'alpha': self.learningRate}
         numExperiences = int(testDict['numExperiences'])
         maxPreExperiences = 10
-        self.numsExperiencesForDisplay = range(
-            min(numExperiences, maxPreExperiences))
+        self.numsExperiencesForDisplay = list(range(
+            min(numExperiences, maxPreExperiences)))
         self.testOutFile = testDict['test_out_file']
         if maxPreExperiences < numExperiences:
             self.numsExperiencesForDisplay.append(numExperiences)
@@ -584,8 +589,7 @@ class QLearningTest(testClasses.TestCase):
     def runAgent(self, moduleDict, numExperiences):
         agent = moduleDict['qlearningAgents'].QLearningAgent(**self.opts)
         states = sorted(
-            filter(lambda state: len(self.grid.getPossibleActions(state)) > 0,
-                   self.grid.getStates()))
+            [state for state in self.grid.getStates() if len(self.grid.getPossibleActions(state)) > 0])
         randObj = FixedRandom().random
         # choose a random start state and a random possible action from that state
         # get the next state and reward from the transition function
@@ -714,8 +718,7 @@ class EpsilonGreedyTest(testClasses.TestCase):
     def runAgent(self, moduleDict):
         agent = moduleDict['qlearningAgents'].QLearningAgent(**self.opts)
         states = sorted(
-            filter(lambda state: len(self.grid.getPossibleActions(state)) > 0,
-                   self.grid.getStates()))
+            [state for state in self.grid.getStates() if len(self.grid.getPossibleActions(state)) > 0])
         randObj = FixedRandom().random
         # choose a random start state and a random possible action from that state
         # get the next state and reward from the transition function
@@ -744,9 +747,9 @@ class EpsilonGreedyTest(testClasses.TestCase):
             # g = n * [(1-e) + e/k] -> e = (n - g) / (n - n/k)
             empiricalEpsilonNumerator = self.numIterations - numGreedyChoices
             empiricalEpsilonDenominator = self.numIterations - \
-                self.numIterations / float(numLegalActions)
-            empiricalEpsilon = empiricalEpsilonNumerator / \
-                empiricalEpsilonDenominator
+                old_div(self.numIterations, float(numLegalActions))
+            empiricalEpsilon = old_div(empiricalEpsilonNumerator, \
+                empiricalEpsilonDenominator)
             error = abs(empiricalEpsilon - self.epsilon)
             if error > tolerance:
                 self.addMessage(
@@ -829,7 +832,7 @@ class EvalAgentTest(testClasses.TestCase):
             'games': games, 'scores': [g.state.getScore() for g in games],
             'timeouts': [g.agentTimeout for g in games].count(True), 'crashes': [g.agentCrashed for g in games].count(True)}
 
-        averageScore = sum(stats['scores']) / float(len(stats['scores']))
+        averageScore = old_div(sum(stats['scores']), float(len(stats['scores'])))
         nonTimeouts = numGames - stats['timeouts']
         wins = stats['wins']
 

--- a/rlpy/Domains/PacmanPackage/reinforcementTestClasses.py
+++ b/rlpy/Domains/PacmanPackage/reinforcementTestClasses.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
 # reinforcementTestClasses.py
 # ---------------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -10,6 +12,11 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import super
+from builtins import open
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from builtins import str
 from builtins import range

--- a/rlpy/Domains/PacmanPackage/testClasses.py
+++ b/rlpy/Domains/PacmanPackage/testClasses.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 # testClasses.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -10,6 +13,9 @@ from __future__ import print_function
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
 # import modules from python standard library
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 import inspect
 import re

--- a/rlpy/Domains/PacmanPackage/testClasses.py
+++ b/rlpy/Domains/PacmanPackage/testClasses.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # testClasses.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +10,7 @@
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
 # import modules from python standard library
+from builtins import object
 import inspect
 import re
 import sys
@@ -20,7 +22,7 @@ import sys
 class Question(object):
 
     def raiseNotDefined(self):
-        print 'Method not implemented: %s' % inspect.stack()[1][3]
+        print('Method not implemented: %s' % inspect.stack()[1][3])
         sys.exit(1)
 
     def __init__(self, questionDict, display):
@@ -129,7 +131,7 @@ class NumberPassedQuestion(Question):
 class TestCase(object):
 
     def raiseNotDefined(self):
-        print 'Method not implemented: %s' % inspect.stack()[1][3]
+        print('Method not implemented: %s' % inspect.stack()[1][3])
         sys.exit(1)
 
     def getPath(self):

--- a/rlpy/Domains/PacmanPackage/testParser.py
+++ b/rlpy/Domains/PacmanPackage/testParser.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # testParser.py
 # -------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,6 +9,7 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import object
 import re
 import sys
 
@@ -65,7 +67,7 @@ class TestParser(object):
                 test['__emit__'].append(("multiline", m.group(1)))
                 i += 1
                 continue
-            print 'error parsing test file: %s' % self.path
+            print('error parsing test file: %s' % self.path)
             sys.exit(1)
         return test
 

--- a/rlpy/Domains/PacmanPackage/testParser.py
+++ b/rlpy/Domains/PacmanPackage/testParser.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 # testParser.py
 # -------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +12,9 @@ from __future__ import print_function
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 import re
 import sys

--- a/rlpy/Domains/PacmanPackage/textDisplay.py
+++ b/rlpy/Domains/PacmanPackage/textDisplay.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import division
 # textDisplay.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -10,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/rlpy/Domains/PacmanPackage/textDisplay.py
+++ b/rlpy/Domains/PacmanPackage/textDisplay.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # textDisplay.py
 # --------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,7 +10,10 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-import pacman
+from builtins import str
+from builtins import range
+from builtins import object
+from . import pacman
 import time
 
 DRAW_EVERY = 1
@@ -17,7 +22,7 @@ DISPLAY_MOVES = False
 QUIET = False  # Supresses output
 
 
-class NullGraphics:
+class NullGraphics(object):
 
     def initialize(self, state, isBlue=False):
         pass
@@ -32,7 +37,7 @@ class NullGraphics:
         time.sleep(SLEEP_TIME)
 
     def draw(self, state):
-        print state
+        print(state)
 
     def updateDistributions(self, dist):
         pass
@@ -41,7 +46,7 @@ class NullGraphics:
         pass
 
 
-class PacmanGraphics:
+class PacmanGraphics(object):
 
     def __init__(self, speed=None):
         if speed is not None:
@@ -62,7 +67,7 @@ class PacmanGraphics:
             if DISPLAY_MOVES:
                 ghosts = [pacman.nearestPoint(state.getGhostPosition(i))
                           for i in range(1, numAgents)]
-                print "%4d) P: %-8s" % (self.turn, str(pacman.nearestPoint(state.getPacmanPosition()))), '| Score: %-5d' % state.score, '| Ghosts:', ghosts
+                print("%4d) P: %-8s" % (self.turn, str(pacman.nearestPoint(state.getPacmanPosition()))), '| Score: %-5d' % state.score, '| Ghosts:', ghosts)
             if self.turn % DRAW_EVERY == 0:
                 self.draw(state)
                 self.pause()
@@ -73,7 +78,7 @@ class PacmanGraphics:
         time.sleep(SLEEP_TIME)
 
     def draw(self, state):
-        print state
+        print(state)
 
     def finish(self):
         pass

--- a/rlpy/Domains/PacmanPackage/textGridworldDisplay.py
+++ b/rlpy/Domains/PacmanPackage/textGridworldDisplay.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 # textGridworldDisplay.py
 # -----------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -11,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import dict
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import zip

--- a/rlpy/Domains/PacmanPackage/textGridworldDisplay.py
+++ b/rlpy/Domains/PacmanPackage/textGridworldDisplay.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 # textGridworldDisplay.py
 # -----------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,11 +11,18 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-import util
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
+from . import util
 from functools import reduce
 
 
-class TextGridworldDisplay:
+class TextGridworldDisplay(object):
 
     def __init__(self, gridworld):
         self.gridworld = gridworld
@@ -25,7 +35,7 @@ class TextGridworldDisplay:
 
     def displayValues(self, agent, currentState=None, message=None):
         if message is not None:
-            print message
+            print(message)
         values = util.Counter()
         policy = {}
         states = self.gridworld.getStates()
@@ -36,12 +46,12 @@ class TextGridworldDisplay:
 
     def displayNullValues(self, agent, currentState=None, message=None):
         if message is not None:
-            print message
+            print(message)
         prettyPrintNullValues(self.gridworld, currentState)
 
     def displayQValues(self, agent, currentState=None, message=None):
         if message is not None:
-            print message
+            print(message)
         qValues = util.Counter()
         states = self.gridworld.getStates()
         for state in states:
@@ -85,16 +95,16 @@ def prettyPrintValues(gridWorld, values, policy=None, currentState=None):
                     text[1] = '*'
                 else:
                     text[1] = "|" + ' ' * \
-                        int((l - 1) / 2 - 1) + '*' + \
-                        ' ' * int((l) / 2 - 1) + "|"
+                        int(old_div((l - 1), 2) - 1) + '*' + \
+                        ' ' * int(old_div((l), 2) - 1) + "|"
             if action == 'east':
                 text[2] = '  ' + text[2] + ' >'
             elif action == 'west':
                 text[2] = '< ' + text[2] + '  '
             elif action == 'north':
-                text[0] = ' ' * int(maxLen / 2) + '^' + ' ' * int(maxLen / 2)
+                text[0] = ' ' * int(old_div(maxLen, 2)) + '^' + ' ' * int(old_div(maxLen, 2))
             elif action == 'south':
-                text[4] = ' ' * int(maxLen / 2) + 'v' + ' ' * int(maxLen / 2)
+                text[4] = ' ' * int(old_div(maxLen, 2)) + 'v' + ' ' * int(old_div(maxLen, 2))
             newCell = "\n".join(text)
             newRow.append(newCell)
         newRows.append(newRow)
@@ -105,7 +115,7 @@ def prettyPrintValues(gridWorld, values, policy=None, currentState=None):
     colLabels = [str(colNum) for colNum in range(numCols)]
     colLabels.insert(0, ' ')
     finalRows = [colLabels] + newRows
-    print indent(finalRows, separateRows=True, delim='|', prefix='|', postfix='|', justify='center', hasHeader=True)
+    print(indent(finalRows, separateRows=True, delim='|', prefix='|', postfix='|', justify='center', hasHeader=True))
 
 
 def prettyPrintNullValues(gridWorld, currentState=None):
@@ -155,17 +165,17 @@ def prettyPrintNullValues(gridWorld, currentState=None):
                     text[1] = '*'
                 else:
                     text[1] = "|" + ' ' * \
-                        int((l - 1) / 2 - 1) + '*' + \
-                        ' ' * int((l) / 2 - 1) + "|"
+                        int(old_div((l - 1), 2) - 1) + '*' + \
+                        ' ' * int(old_div((l), 2) - 1) + "|"
 
             if action == 'east':
                 text[2] = '  ' + text[2] + ' >'
             elif action == 'west':
                 text[2] = '< ' + text[2] + '  '
             elif action == 'north':
-                text[0] = ' ' * int(maxLen / 2) + '^' + ' ' * int(maxLen / 2)
+                text[0] = ' ' * int(old_div(maxLen, 2)) + '^' + ' ' * int(old_div(maxLen, 2))
             elif action == 'south':
-                text[4] = ' ' * int(maxLen / 2) + 'v' + ' ' * int(maxLen / 2)
+                text[4] = ' ' * int(old_div(maxLen, 2)) + 'v' + ' ' * int(old_div(maxLen, 2))
             newCell = "\n".join(text)
             newRow.append(newCell)
         newRows.append(newRow)
@@ -176,7 +186,7 @@ def prettyPrintNullValues(gridWorld, currentState=None):
     colLabels = [str(colNum) for colNum in range(numCols)]
     colLabels.insert(0, ' ')
     finalRows = [colLabels] + newRows
-    print indent(finalRows, separateRows=True, delim='|', prefix='|', postfix='|', justify='center', hasHeader=True)
+    print(indent(finalRows, separateRows=True, delim='|', prefix='|', postfix='|', justify='center', hasHeader=True))
 
 
 def prettyPrintQValues(gridWorld, qValues, currentState=None):
@@ -254,7 +264,7 @@ def prettyPrintQValues(gridWorld, qValues, currentState=None):
     colLabels.insert(0, ' ')
     finalRows = [colLabels] + newRows
 
-    print indent(finalRows, separateRows=True, delim='|', prefix='|', postfix='|', justify='center', hasHeader=True)
+    print(indent(finalRows, separateRows=True, delim='|', prefix='|', postfix='|', justify='center', hasHeader=True))
 
 
 def border(text):
@@ -268,7 +278,7 @@ def border(text):
 # Indenting code based on a post from George Sakkis
 # (http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/267662)
 
-import cStringIO
+import io
 import operator
 
 
@@ -292,12 +302,12 @@ def indent(rows, hasHeader=False, headerChar='-', delim=' | ', justify='left',
     def rowWrapper(row):
         newRows = [wrapfunc(item).split('\n') for item in row]
         return (
-            [[substr or '' for substr in item] for item in map(None, *newRows)]
+            [[substr or '' for substr in item] for item in list(*newRows)]
         )
     # break each logical row into one or more physical ones
     logicalRows = [rowWrapper(row) for row in rows]
     # columns of physical rows
-    columns = map(None, *reduce(operator.add, logicalRows))
+    columns = list(*reduce(operator.add, logicalRows))
     # get the maximum of each column by the string length of its items
     maxWidths = [max([len(str(item)) for item in column])
                  for column in columns]
@@ -306,17 +316,16 @@ def indent(rows, hasHeader=False, headerChar='-', delim=' | ', justify='left',
     # select the appropriate justify method
     justify = {'center': str.center, 'right':
                str.rjust, 'left': str.ljust}[justify.lower()]
-    output = cStringIO.StringIO()
+    output = io.StringIO()
     if separateRows:
-        print >> output, rowSeparator
+        print(rowSeparator, file=output)
     for physicalRows in logicalRows:
         for row in physicalRows:
-            print >> output, \
-                prefix \
+            print(prefix \
                 + delim.join([justify(str(item), width) for (item, width) in zip(row, maxWidths)]) \
-                + postfix
+                + postfix, file=output)
         if separateRows or hasHeader:
-            print >> output, rowSeparator
+            print(rowSeparator, file=output)
             hasHeader = False
     return output.getvalue()
 
@@ -327,17 +336,17 @@ def wrap_always(text, width):
     """A simple word-wrap function that wraps text on exactly width characters.
        It doesn't split the text in words."""
     return '\n'.join([text[width * i:width * (i + 1)]
-                      for i in xrange(int(math.ceil(1. * len(text) / width)))])
+                      for i in range(int(math.ceil(1. * len(text) / width)))])
 
 
 # TEST OF DISPLAY CODE
 
 if __name__ == '__main__':
-    import gridworld
-    import util
+    from . import gridworld
+    from . import util
 
     grid = gridworld.getCliffGrid3()
-    print grid.getStates()
+    print(grid.getStates())
 
     policy = dict([(state, 'east') for state in grid.getStates()])
     values = util.Counter(dict([(state, 1000.23)

--- a/rlpy/Domains/PacmanPackage/util.py
+++ b/rlpy/Domains/PacmanPackage/util.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 # util.py
 # -------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -10,6 +12,7 @@ from __future__ import print_function
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import input

--- a/rlpy/Domains/PacmanPackage/util.py
+++ b/rlpy/Domains/PacmanPackage/util.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import print_function
 # util.py
 # -------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,14 +10,22 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import input
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import sys
 import inspect
 import heapq
 import random
-import cStringIO
+import io
 
 
-class FixedRandom:
+class FixedRandom(object):
 
     def __init__(self):
         fixedState = (
@@ -117,7 +127,7 @@ class FixedRandom:
 """
 
 
-class Stack:
+class Stack(object):
 
     "A container with a last-in-first-out (LIFO) queuing policy."
 
@@ -137,7 +147,7 @@ class Stack:
         return len(self.list) == 0
 
 
-class Queue:
+class Queue(object):
 
     "A container with a first-in-first-out (FIFO) queuing policy."
 
@@ -160,7 +170,7 @@ class Queue:
         return len(self.list) == 0
 
 
-class PriorityQueue:
+class PriorityQueue(object):
 
     """
       Implements a priority queue data structure. Each inserted item
@@ -289,9 +299,9 @@ class Counter(dict):
         """
         Returns the key with the highest value.
         """
-        if len(self.keys()) == 0:
+        if len(list(self.keys())) == 0:
             return None
-        all = self.items()
+        all = list(self.items())
         values = [x[1] for x in all]
         maxIndex = values.index(max(values))
         return all[maxIndex][0]
@@ -308,7 +318,7 @@ class Counter(dict):
         >>> a.sortedKeys()
         ['second', 'third', 'first']
         """
-        sortedItems = self.items()
+        sortedItems = list(self.items())
         compare = lambda x, y: sign(y[1] - x[1])
         sortedItems.sort(cmp=compare)
         return [x[0] for x in sortedItems]
@@ -329,8 +339,8 @@ class Counter(dict):
         total = float(self.totalCount())
         if total == 0:
             return
-        for key in self.keys():
-            self[key] = self[key] / total
+        for key in list(self.keys()):
+            self[key] = old_div(self[key], total)
 
     def divideAll(self, divisor):
         """
@@ -387,7 +397,7 @@ class Counter(dict):
         >>> a['first']
         1
         """
-        for key, value in y.items():
+        for key, value in list(y.items()):
             self[key] += value
 
     def __add__(self, y):
@@ -448,7 +458,7 @@ def raiseNotDefined():
     line = inspect.stack()[1][2]
     method = inspect.stack()[1][3]
 
-    print "*** Method not implemented: %s at line %s of %s" % (method, line, fileName)
+    print("*** Method not implemented: %s at line %s of %s" % (method, line, fileName))
     sys.exit(1)
 
 
@@ -462,16 +472,16 @@ def normalize(vectorOrCounter):
         total = float(counter.totalCount())
         if total == 0:
             return counter
-        for key in counter.keys():
+        for key in list(counter.keys()):
             value = counter[key]
-            normalizedCounter[key] = value / total
+            normalizedCounter[key] = old_div(value, total)
         return normalizedCounter
     else:
         vector = vectorOrCounter
         s = float(sum(vector))
         if s == 0:
             return vector
-        return [el / s for el in vector]
+        return [old_div(el, s) for el in vector]
 
 
 def nSample(distribution, values, n):
@@ -492,7 +502,7 @@ def nSample(distribution, values, n):
 
 def sample(distribution, values=None):
     if isinstance(distribution, Counter):
-        items = distribution.items()
+        items = list(distribution.items())
         distribution = [i[1] for i in items]
         values = [i[0] for i in items]
     if sum(distribution) != 1:
@@ -506,7 +516,7 @@ def sample(distribution, values=None):
 
 
 def sampleFromCounter(ctr):
-    items = ctr.items()
+    items = list(ctr.items())
     return sample([v for k, v in items], [k for k, v in items])
 
 
@@ -596,11 +606,11 @@ def lookup(name, namespace):
         module = __import__(moduleName)
         return getattr(module, objName)
     else:
-        modules = [obj for obj in namespace.values() if str(
+        modules = [obj for obj in list(namespace.values()) if str(
             type(obj)) == "<type 'module'>"]
         options = [getattr(module, name)
                    for module in modules if name in dir(module)]
-        options += [obj[1] for obj in namespace.items() if obj[0] == name]
+        options += [obj[1] for obj in list(namespace.items()) if obj[0] == name]
         if len(options) == 1:
             return options[0]
         if len(options) > 1:
@@ -612,8 +622,8 @@ def pause():
     """
     Pauses the output stream awaiting user feedback.
     """
-    print "<Press enter/return to continue>"
-    raw_input()
+    print("<Press enter/return to continue>")
+    input()
 
 
 # code to handle timeouts
@@ -634,7 +644,7 @@ class TimeoutFunctionException(Exception):
     pass
 
 
-class TimeoutFunction:
+class TimeoutFunction(object):
 
     def __init__(self, function, timeout):
         self.timeout = timeout
@@ -669,7 +679,7 @@ _ORIGINAL_STDERR = None
 _MUTED = False
 
 
-class WritableNull:
+class WritableNull(object):
 
     def write(self, string):
         pass

--- a/rlpy/Domains/PacmanPackage/valueIterationAgents.py
+++ b/rlpy/Domains/PacmanPackage/valueIterationAgents.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 # valueIterationAgents.py
 # -----------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -9,6 +12,8 @@ from __future__ import absolute_import
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
+from future import standard_library
+standard_library.install_aliases()
 from . import mdp
 from . import util
 

--- a/rlpy/Domains/PacmanPackage/valueIterationAgents.py
+++ b/rlpy/Domains/PacmanPackage/valueIterationAgents.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # valueIterationAgents.py
 # -----------------------
 # Licensing Information: Please do not distribute or publish solutions to this
@@ -8,10 +9,10 @@
 # Abbeel in Spring 2013.
 # For more info, see http://inst.eecs.berkeley.edu/~cs188/pacman/pacman.html
 
-import mdp
-import util
+from . import mdp
+from . import util
 
-from learningAgents import ValueEstimationAgent
+from .learningAgents import ValueEstimationAgent
 
 
 class ValueIterationAgent(ValueEstimationAgent):

--- a/rlpy/Domains/Pinball.py
+++ b/rlpy/Domains/Pinball.py
@@ -1,10 +1,19 @@
 """Pinball domain for reinforcement learning
 """
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import next
+from builtins import zip
+from builtins import map
+from builtins import range
+from builtins import object
+from past.utils import old_div
 from .Domain import Domain
 import numpy as np
-from itertools import tee, izip
+from itertools import tee
 import itertools
-from Tkinter import Tk, Canvas
+from tkinter import Tk, Canvas
 import os
 from rlpy.Tools import __rlpy_location__
 
@@ -124,7 +133,7 @@ class Pinball(Domain):
         return self.environment.episode_ended()
 
 
-class BallModel:
+class BallModel(object):
 
     """ This class maintains the state of the ball
     in the pinball domain. It takes care of moving
@@ -152,8 +161,8 @@ class BallModel:
         :param delta_ydot: The change in velocity in the y direction
         :type delta_ydot: float
         """
-        self.xdot += delta_xdot / 5.0
-        self.ydot += delta_ydot / 5.0
+        self.xdot += old_div(delta_xdot, 5.0)
+        self.ydot += old_div(delta_ydot, 5.0)
         self.xdot = self._clip(self.xdot)
         self.ydot = self._clip(self.ydot)
 
@@ -176,7 +185,7 @@ class BallModel:
         return val
 
 
-class PinballObstacle:
+class PinballObstacle(object):
 
     """ This class represents a single polygon obstacle in the
     pinball domain and detects when a :class:`BallModel` hits it.
@@ -219,7 +228,7 @@ class PinballObstacle:
         a, b = tee(np.vstack([np.array(self.points), self.points[0]]))
         next(b, None)
         intercept_found = False
-        for pt_pair in izip(a, b):
+        for pt_pair in zip(a, b):
             if self._intercept_edge(pt_pair, ball):
                 if intercept_found:
                     # Ball has hit a corner
@@ -289,7 +298,7 @@ class PinballObstacle:
         if angle1 > np.pi:
             angle2 -= np.pi
 
-        if np.abs(angle1 - (np.pi / 2.0)) < np.abs(angle2 - (np.pi / 2.0)):
+        if np.abs(angle1 - (old_div(np.pi, 2.0))) < np.abs(angle2 - (old_div(np.pi, 2.0))):
             return intersect1
         return intersect2
 
@@ -324,8 +333,8 @@ class PinballObstacle:
         obstacle_edge = pt_pair[1] - pt_pair[0]
         difference = np.array(ball.position) - pt_pair[0]
 
-        scalar_proj = difference.dot(
-            obstacle_edge) / obstacle_edge.dot(obstacle_edge)
+        scalar_proj = old_div(difference.dot(
+            obstacle_edge), obstacle_edge.dot(obstacle_edge))
         if scalar_proj > 1.0:
             scalar_proj = 1.0
         elif scalar_proj < 0.0:
@@ -345,7 +354,7 @@ class PinballObstacle:
             if angle > np.pi:
                 angle = 2 * np.pi - angle
 
-            if angle > np.pi / 1.99:
+            if angle > old_div(np.pi, 1.99):
                 return False
 
             return True
@@ -353,7 +362,7 @@ class PinballObstacle:
             return False
 
 
-class PinballModel:
+class PinballModel(object):
 
     """ This class is a self-contained model of the pinball
     domain for reinforcement learning.
@@ -399,12 +408,12 @@ class PinballModel:
                     continue
                 elif tokens[0] == 'polygon':
                     self.obstacles.append(
-                        PinballObstacle(zip(*[iter(map(float, tokens[1:]))] * 2)))
+                        PinballObstacle(list(zip(*[iter(map(float, tokens[1:]))] * 2))))
                 elif tokens[0] == 'target':
                     self.target_pos = [float(tokens[1]), float(tokens[2])]
                     self.target_rad = float(tokens[3])
                 elif tokens[0] == 'start':
-                    start_pos = zip(*[iter(map(float, tokens[1:]))] * 2)
+                    start_pos = list(zip(*[iter(map(float, tokens[1:]))] * 2))
                 elif tokens[0] == 'ball':
                     ball_rad = float(tokens[1])
         self.start_pos = start_pos[0]
@@ -432,7 +441,7 @@ class PinballModel:
         :type action: int
 
         """
-        for i in xrange(20):
+        for i in range(20):
             if i == 0:
                 self.ball.add_impulse(*self.action_effects[action])
 
@@ -491,7 +500,7 @@ class PinballModel:
             self.ball.position[1] = 0.05
 
 
-class PinballView:
+class PinballView(object):
 
     """ This class displays a :class:`PinballModel`
 
@@ -520,7 +529,7 @@ class PinballView:
         self.TARGET_COLOR = [255, 0, 0]
 
         for obs in model.obstacles:
-            coords_list = map(self._to_pixels, obs.points)
+            coords_list = list(map(self._to_pixels, obs.points))
             chain = itertools.chain(*coords_list)
             coords = list(chain)
             self.screen.create_polygon(coords, fill='blue')

--- a/rlpy/Domains/Pinball.py
+++ b/rlpy/Domains/Pinball.py
@@ -1,6 +1,12 @@
 """Pinball domain for reinforcement learning
 """
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import super
+from builtins import open
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
 from builtins import next

--- a/rlpy/Domains/PuddleWorld.py
+++ b/rlpy/Domains/PuddleWorld.py
@@ -1,5 +1,7 @@
 """Puddle world domain (navigation task)."""
+from __future__ import division
 
+from past.utils import old_div
 from .Domain import Domain
 import numpy as np
 import matplotlib.pyplot as plt
@@ -93,7 +95,7 @@ class PuddleWorld(Domain):
         # compute puddle influence
         d = self.puddles[:, 1, :] - self.puddles[:, 0, :]
         denom = (d ** 2).sum(axis=1)
-        g = ((s - self.puddles[:, 0, :]) * d).sum(axis=1) / denom
+        g = old_div(((s - self.puddles[:, 0, :]) * d).sum(axis=1), denom)
         g = np.minimum(g, 1)
         g = np.maximum(g, 0)
         dists = np.sqrt(((self.puddles[:, 0, :] + g * d - s) ** 2).sum(axis=1))

--- a/rlpy/Domains/PuddleWorld.py
+++ b/rlpy/Domains/PuddleWorld.py
@@ -1,6 +1,12 @@
 """Puddle world domain (navigation task)."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Domain import Domain
 import numpy as np

--- a/rlpy/Domains/PuddleWorld.py
+++ b/rlpy/Domains/PuddleWorld.py
@@ -112,11 +112,13 @@ class PuddleWorld(Domain):
             self.reward_im = plt.imshow(self.reward_map, extent=(0, 1, 0, 1),
                                         origin="lower")
             self.state_mark = plt.plot(s[0], s[1], 'kd', markersize=20)
-            plt.draw()
+            plt.figure("Domain").canvas.draw()
+            plt.figure("Domain").canvas.flush_events()
         else:
             self.domain_fig = plt.figure("Domain")
             self.state_mark[0].set_data([s[0]], [s[1]])
-            plt.draw()
+            plt.figure("Domain").canvas.draw()
+            plt.figure("Domain").canvas.flush_events()
 
     def showLearning(self, representation):
         a = np.zeros((2))

--- a/rlpy/Domains/RCCar.py
+++ b/rlpy/Domains/RCCar.py
@@ -1,6 +1,12 @@
 """RC-Car domain"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Tools import plt, bound, wrap, mpatches, id2vec
 import matplotlib as mpl

--- a/rlpy/Domains/RCCar.py
+++ b/rlpy/Domains/RCCar.py
@@ -1,5 +1,7 @@
 """RC-Car domain"""
+from __future__ import division
 
+from past.utils import old_div
 from rlpy.Tools import plt, bound, wrap, mpatches, id2vec
 import matplotlib as mpl
 from .Domain import Domain
@@ -42,12 +44,12 @@ class RCCar(Domain):
 
     ROOM_WIDTH = 3  # in meters
     ROOM_HEIGHT = 2  # in meters
-    XMIN = -ROOM_WIDTH / 2.0
-    XMAX = ROOM_WIDTH / 2.0
-    YMIN = -ROOM_HEIGHT / 2.0
-    YMAX = ROOM_HEIGHT / 2.0
+    XMIN = old_div(-ROOM_WIDTH, 2.0)
+    XMAX = old_div(ROOM_WIDTH, 2.0)
+    YMIN = old_div(-ROOM_HEIGHT, 2.0)
+    YMAX = old_div(ROOM_HEIGHT, 2.0)
     ACCELERATION = .1
-    TURN_ANGLE = np.pi / 6
+    TURN_ANGLE = old_div(np.pi, 6)
     SPEEDMIN = -.3
     SPEEDMAX = .3
     HEADINGMIN = -np.pi
@@ -130,7 +132,7 @@ class RCCar(Domain):
         # Plot the car
         x, y, speed, heading = s
         car_xmin = x - self.REAR_WHEEL_RELATIVE_LOC
-        car_ymin = y - self.CAR_WIDTH / 2.
+        car_ymin = y - old_div(self.CAR_WIDTH, 2.)
         if self.domain_fig is None:  # Need to initialize the figure
             self.domain_fig = plt.figure()
             # Goal

--- a/rlpy/Domains/Swimmer.py
+++ b/rlpy/Domains/Swimmer.py
@@ -1,5 +1,10 @@
 """multi-link swimmer moving in a fluid."""
+from __future__ import division
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 from .Domain import Domain
 import numpy as np
 from rlpy.Tools import plt, rk4, cartesian, colors
@@ -65,7 +70,7 @@ class Swimmer(Domain):
         Q[-1, :] = self.masses
         A = np.eye(self.d, k=1) + np.eye(self.d)
         A[-1, -1] = 0.
-        self.P = np.dot(np.linalg.inv(Q), A * self.lengths[None, :]) / 2.
+        self.P = old_div(np.dot(np.linalg.inv(Q), A * self.lengths[None, :]), 2.)
 
         self.U = np.eye(self.d) - np.eye(self.d, k=-1)
         self.U = self.U[:, :-1]
@@ -82,7 +87,7 @@ class Swimmer(Domain):
         self.statespace_limits = [[-15, 15]] * 2 + [[-np.pi, np.pi]] * (d - 1) \
             + [[-2, 2]] * 2 + [[-np.pi * 2, np.pi * 2]] * d
         self.statespace_limits = np.array(self.statespace_limits)
-        self.continuous_dims = range(self.statespace_limits.shape[0])
+        self.continuous_dims = list(range(self.statespace_limits.shape[0]))
         super(Swimmer, self).__init__()
 
     def s0(self):
@@ -113,8 +118,8 @@ class Swimmer(Domain):
         R2 = R + .5 * self.lengths[:, None] * T
         Rx = np.hstack([R1[:, 0], R2[:, 0]]) + self.pos_cm[0]
         Ry = np.hstack([R1[:, 1], R2[:, 1]]) + self.pos_cm[1]
-        print Rx
-        print Ry
+        print(Rx)
+        print(Ry)
         f = plt.figure("Swimmer Domain")
         if not hasattr(self, "swimmer_lines"):
             plt.plot(0., 0., "ro")
@@ -350,10 +355,10 @@ def dsdt(s, t, a, P, I, G, U, lengths, masses, k1, k2):
     ds = np.zeros_like(s)
     ds[:2] = vcm
     ds[2:2 + d] = dtheta
-    ds[2 + d] = - \
-        (k1 * np.sum(-sth * Vn) + k2 * np.sum(cth * Vt)) / np.sum(masses)
-    ds[3 + d] = - \
-        (k1 * np.sum(cth * Vn) + k2 * np.sum(sth * Vt)) / np.sum(masses)
+    ds[2 + d] = old_div(- \
+        (k1 * np.sum(-sth * Vn) + k2 * np.sum(cth * Vt)), np.sum(masses))
+    ds[3 + d] = old_div(- \
+        (k1 * np.sum(cth * Vn) + k2 * np.sum(sth * Vt)), np.sum(masses))
     ds[4 + d:] = np.linalg.solve(EL3, EL1 + EL2 + np.dot(U, a))
     return ds
 

--- a/rlpy/Domains/Swimmer.py
+++ b/rlpy/Domains/Swimmer.py
@@ -130,7 +130,8 @@ class Swimmer(Domain):
         else:
             self.swimmer_lines.set_data(Rx, Ry)
             self.action_text.set_text(str(a))
-        plt.draw()
+        plt.figure("Swimmer Domain").canvas.draw()
+        plt.figure("Swimmer Domain").canvas.flush_events()
 
     def showLearning(self, representation):
         good_pol = SwimmerPolicy(

--- a/rlpy/Domains/Swimmer.py
+++ b/rlpy/Domains/Swimmer.py
@@ -1,7 +1,12 @@
 """multi-link swimmer moving in a fluid."""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/rlpy/Domains/SystemAdministrator.py
+++ b/rlpy/Domains/SystemAdministrator.py
@@ -1,6 +1,5 @@
 """Network administrator task."""
 from __future__ import division
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 

--- a/rlpy/Domains/SystemAdministrator.py
+++ b/rlpy/Domains/SystemAdministrator.py
@@ -1,5 +1,8 @@
 """Network administrator task."""
 
+from builtins import zip
+from builtins import map
+from builtins import range
 from rlpy.Tools import plt, nx
 import numpy as np
 import csv
@@ -131,7 +134,7 @@ class SystemAdministrator(Domain):
         reader = csv.reader(f, delimiter=',')
         self.computers_num = 0
         for row in reader:
-            row = map(int, row)
+            row = list(map(int, row))
             _Neighbors.append(row)
             self.computers_num = max(max(row) + 1, self.computers_num)
         self.setUniqueEdges(_Neighbors)
@@ -257,7 +260,7 @@ class SystemAdministrator(Domain):
     def s0(self):
         # Omits final index
         self.state = np.array(
-            [self.RUNNING for dummy in xrange(0, self.state_space_dims)])
+            [self.RUNNING for dummy in range(0, self.state_space_dims)])
         return self.state.copy(), self.isTerminal(), self.possibleActions()
 
     def possibleActions(self):

--- a/rlpy/Domains/SystemAdministrator.py
+++ b/rlpy/Domains/SystemAdministrator.py
@@ -130,7 +130,7 @@ class SystemAdministrator(Domain):
 
         """
         _Neighbors = []
-        f = open(path, 'rb')
+        f = open(path, 'r')
         reader = csv.reader(f, delimiter=',')
         self.computers_num = 0
         for row in reader:
@@ -142,6 +142,8 @@ class SystemAdministrator(Domain):
 
     def showDomain(self, a=0):
         s = self.state
+        plt.figure("Domain")
+
         if self.networkGraph is None:  # or self.networkPos is None:
             self.networkGraph = nx.Graph()
             # enumerate all computer_ids, simulatenously iterating through
@@ -215,7 +217,8 @@ class SystemAdministrator(Domain):
                     width=2,
                     style='dotted')
         nx.draw_networkx_labels(self.networkGraph, self.networkPos)
-        plt.draw()
+        plt.figure("Domain").canvas.draw()
+        plt.figure("Domain").canvas.flush_events()
 
     def step(self, a):
         # ns = s[:] # make copy of state so as not to affect original mid-step

--- a/rlpy/Domains/SystemAdministrator.py
+++ b/rlpy/Domains/SystemAdministrator.py
@@ -1,5 +1,13 @@
 """Network administrator task."""
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from builtins import map
 from builtins import range

--- a/rlpy/Domains/__init__.py
+++ b/rlpy/Domains/__init__.py
@@ -1,4 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 #from Domain import Domain
+from future import standard_library
+standard_library.install_aliases()
 from .HelicopterHover import HelicopterHover, HelicopterHoverExtended
 from .HIVTreatment import HIVTreatment
 from .PuddleWorld import PuddleWorld

--- a/rlpy/Experiments/Experiment.py
+++ b/rlpy/Experiments/Experiment.py
@@ -1,5 +1,11 @@
 """Standard Experiment for Learning Control in RL."""
+from __future__ import division
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import logging
 from rlpy.Tools import plt
 import numpy as np
@@ -10,7 +16,7 @@ from rlpy.Tools import deltaT, clock, hhmmss
 from rlpy.Tools import className, checkNCreateDirectory
 from rlpy.Tools import printClass
 import rlpy.Tools.results
-from rlpy.Tools import lower
+# from rlpy.Tools import lower
 import os
 import rlpy.Tools.ipshell
 import json
@@ -254,7 +260,7 @@ class Experiment(object):
         idx[idx < 0] = 0
         idx[idx >= d + 2] = d + 1
         #import ipdb; ipdb.set_trace()
-        counts[range(counts.shape[0]), idx] += 1
+        counts[list(range(counts.shape[0])), idx] += 1
 
     def run_from_commandline(self):
         """
@@ -396,7 +402,7 @@ class Experiment(object):
                 self.domain.show(a, self.agent.representation)
 
             # Check Performance
-            if total_steps % (self.max_steps / self.num_policy_checks) == 0:
+            if total_steps % (old_div(self.max_steps, self.num_policy_checks)) == 0:
                 self.elapsed_time = deltaT(
                     self.start_time) - self.total_eval_time
 
@@ -440,7 +446,7 @@ class Experiment(object):
         performance_steps = 0.
         performance_term = 0.
         performance_discounted_return = 0.
-        for j in xrange(self.checks_per_policy):
+        for j in range(self.checks_per_policy):
             p_ret, p_step, p_term, p_dret = self.performanceRun(
                 total_steps, visualize=visualize > j)
             performance_return += p_ret
@@ -534,17 +540,18 @@ class Experiment(object):
         variables = re.findall("{([^}]*)}", path)
         replacements = {}
         for v in variables:
-            if lower(v).startswith('representation') or lower(v).startswith('policy'):
+            if v.lower().startswith('representation') or v.lower().startswith('policy'):
                 obj = 'self.agent.' + v
             else:
                 obj = 'self.' + v
 
-            if len([x for x in ['self.domain', 'self.agent', 'self.agent.policy', 'self.agent.representation'] if x == lower(obj)]):
+            if len([x for x in ['self.domain', 'self.agent', 'self.agent.policy', 'self.agent.representation'] if x ==
+                obj.lower()]):
                 replacements[v] = eval('className(%s)' % obj)
             else:
                 try:
                     replacements[v] = str(eval('%s' % v))
                 except:
-                    print "Warning: Could not interpret path variable", repr(v)
+                    print("Warning: Could not interpret path variable", repr(v))
 
         return path.format(**replacements)

--- a/rlpy/Experiments/Experiment.py
+++ b/rlpy/Experiments/Experiment.py
@@ -1,7 +1,12 @@
 """Standard Experiment for Learning Control in RL."""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/rlpy/Experiments/MDPSolverExperiment.py
+++ b/rlpy/Experiments/MDPSolverExperiment.py
@@ -1,5 +1,11 @@
 """Standard Experiment for Learning Control in RL"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import rlpy.Tools.ipshell
 from .Experiment import Experiment
 

--- a/rlpy/Experiments/__init__.py
+++ b/rlpy/Experiments/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from .Experiment import Experiment
 from .MDPSolverExperiment import MDPSolverExperiment
 # for backward compatibility with existing experiment scripts

--- a/rlpy/MDPSolvers/MDPSolver.py
+++ b/rlpy/MDPSolvers/MDPSolver.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-# from builtins import open
 from builtins import int
 from future import standard_library
 standard_library.install_aliases()
@@ -164,9 +163,6 @@ class MDPSolver(with_metaclass(ABCMeta, object)):
         print(">>> ", fullpath_output)
         checkNCreateDirectory(self.project_path + '/')
         with open(fullpath_output, "w") as f:
-            print("BOO", self.result)
-            for k, v in self.result.items():
-                print(type(k), type(v))
             json.dump(self.result, f, indent=4, sort_keys=True)
 
     def hasTime(self):

--- a/rlpy/MDPSolvers/MDPSolver.py
+++ b/rlpy/MDPSolvers/MDPSolver.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from builtins import open
 from builtins import int

--- a/rlpy/MDPSolvers/MDPSolver.py
+++ b/rlpy/MDPSolvers/MDPSolver.py
@@ -1,6 +1,5 @@
 """MDP Solver base class."""
 from __future__ import print_function
-from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 
@@ -164,7 +163,7 @@ class MDPSolver(with_metaclass(ABCMeta, object)):
         fullpath_output = os.path.join(self.project_path, self.output_filename)
         print(">>> ", fullpath_output)
         checkNCreateDirectory(self.project_path + '/')
-        with open(fullpath_output, "w") as f:
+        with open(fullpath_output, "wb") as f:
             json.dump(self.result, f, indent=4, sort_keys=True)
 
     def hasTime(self):

--- a/rlpy/MDPSolvers/MDPSolver.py
+++ b/rlpy/MDPSolvers/MDPSolver.py
@@ -1,6 +1,13 @@
 """MDP Solver base class."""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import open
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 from abc import ABCMeta, abstractmethod
 import numpy as np

--- a/rlpy/MDPSolvers/MDPSolver.py
+++ b/rlpy/MDPSolvers/MDPSolver.py
@@ -2,9 +2,8 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
-from builtins import open
+# from builtins import open
 from builtins import int
 from future import standard_library
 standard_library.install_aliases()
@@ -164,7 +163,10 @@ class MDPSolver(with_metaclass(ABCMeta, object)):
         fullpath_output = os.path.join(self.project_path, self.output_filename)
         print(">>> ", fullpath_output)
         checkNCreateDirectory(self.project_path + '/')
-        with open(fullpath_output, "wb") as f:
+        with open(fullpath_output, "w") as f:
+            print("BOO", self.result)
+            for k, v in self.result.items():
+                print(type(k), type(v))
             json.dump(self.result, f, indent=4, sort_keys=True)
 
     def hasTime(self):

--- a/rlpy/MDPSolvers/MDPSolver.py
+++ b/rlpy/MDPSolvers/MDPSolver.py
@@ -1,5 +1,7 @@
 """MDP Solver base class."""
+from __future__ import print_function
 
+from builtins import object
 from abc import ABCMeta, abstractmethod
 import numpy as np
 import logging
@@ -8,6 +10,7 @@ from rlpy.Tools import className, deltaT, hhmmss, clock, l_norm, vec2id, checkNC
 from collections import defaultdict
 import os
 import json
+from future.utils import with_metaclass
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = ["Alborz Geramifard", "Robert H. Klein", "Christoph Dann",
@@ -16,7 +19,7 @@ __license__ = "BSD 3-Clause"
 __author__ = "N. Kemal Ure"
 
 
-class MDPSolver(object):
+class MDPSolver(with_metaclass(ABCMeta, object)):
 
     """MDPSolver is the base class for model based reinforcement learning agents and
     planners.
@@ -41,8 +44,6 @@ class MDPSolver(object):
         show (bool):    Enable visualization?
 
     """
-
-    __metaclass__ = ABCMeta
 
     representation = None  # Link to the representation object
     domain = None  # Link to the domain object
@@ -154,7 +155,7 @@ class MDPSolver(object):
 
     def saveStats(self):
         fullpath_output = os.path.join(self.project_path, self.output_filename)
-        print ">>> ", fullpath_output
+        print(">>> ", fullpath_output)
         checkNCreateDirectory(self.project_path + '/')
         with open(fullpath_output, "w") as f:
             json.dump(self.result, f, indent=4, sort_keys=True)

--- a/rlpy/MDPSolvers/PolicyIteration.py
+++ b/rlpy/MDPSolvers/PolicyIteration.py
@@ -2,7 +2,14 @@
 Performs Bellman Backup on a given s,a pair given a fixed policy by sweeping through the
 state space. Once the errors are bounded, the policy is changed.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from .MDPSolver import MDPSolver
 from rlpy.Tools import className, deltaT, hhmmss, clock, l_norm

--- a/rlpy/MDPSolvers/PolicyIteration.py
+++ b/rlpy/MDPSolvers/PolicyIteration.py
@@ -3,6 +3,7 @@ Performs Bellman Backup on a given s,a pair given a fixed policy by sweeping thr
 state space. Once the errors are bounded, the policy is changed.
 """
 
+from builtins import range
 from .MDPSolver import MDPSolver
 from rlpy.Tools import className, deltaT, hhmmss, clock, l_norm
 from copy import deepcopy
@@ -74,7 +75,7 @@ class PolicyIteration(MDPSolver):
             policy_evaluation_iteration += 1
 
             # Sweep The State Space
-            for i in xrange(0, self.representation.agg_states_num):
+            for i in range(0, self.representation.agg_states_num):
 
                 # Check for solver time
                 if not self.hasTime(): break

--- a/rlpy/MDPSolvers/TrajectoryBasedPolicyIteration.py
+++ b/rlpy/MDPSolvers/TrajectoryBasedPolicyIteration.py
@@ -7,7 +7,14 @@
     * There is solveInMatrixFormat function which does policy evaluation in one shot using samples collected in the matrix format.
       Since the algorithm toss out the samples, convergence is hardly reached because the policy may alternate.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from .MDPSolver import MDPSolver
 from rlpy.Tools import className, hhmmss, deltaT, randSet, hasFunction, solveLinear, regularize, clock, padZeros, l_norm

--- a/rlpy/MDPSolvers/TrajectoryBasedPolicyIteration.py
+++ b/rlpy/MDPSolvers/TrajectoryBasedPolicyIteration.py
@@ -8,6 +8,7 @@
       Since the algorithm toss out the samples, convergence is hardly reached because the policy may alternate.
 """
 
+from builtins import range
 from .MDPSolver import MDPSolver
 from rlpy.Tools import className, hhmmss, deltaT, randSet, hasFunction, solveLinear, regularize, clock, padZeros, l_norm
 from rlpy.Policies import eGreedy
@@ -245,7 +246,7 @@ class TrajectoryBasedPolicyIteration(MDPSolver):
 
             self.A = np.zeros((n * a_num, n * a_num))
             self.b = np.zeros((n * a_num, 1))
-            for i in xrange(self.samples_num):
+            for i in range(self.samples_num):
                 phi_s_a = self.representation.phi_sa(
                     S[i], T[i], Actions[i, 0]).reshape((-1, 1))
                 E_phi_ns_na = self.calculate_expected_phi_ns_na(
@@ -294,12 +295,12 @@ class TrajectoryBasedPolicyIteration(MDPSolver):
             phi_ns_na = np.zeros(
                 self.representation.features_num *
                 self.domain.actions_num)
-            for j in xrange(len(p)):
+            for j in range(len(p)):
                 na = self.policy.pi(ns[j], t[j], pa[j])
                 phi_ns_na += p[j] * self.representation.phi_sa(ns[j], t[j], na)
         else:
             next_states, rewards = self.domain.sampleStep(s, a, ns_samples)
             phi_ns_na = np.mean(
                 [self.representation.phisa(next_states[i],
-                                           self.policy.pi(next_states[i])) for i in xrange(ns_samples)])
+                                           self.policy.pi(next_states[i])) for i in range(ns_samples)])
         return phi_ns_na

--- a/rlpy/MDPSolvers/TrajectoryBasedValueIteration.py
+++ b/rlpy/MDPSolvers/TrajectoryBasedValueIteration.py
@@ -4,6 +4,13 @@
 
 The algorithm terminates if the maximum bellman-error in a consequent set of trajectories is below a threshold
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from .MDPSolver import MDPSolver
 from rlpy.Tools import deltaT, hhmmss, randSet, className, clock
 import numpy as np

--- a/rlpy/MDPSolvers/ValueIteration.py
+++ b/rlpy/MDPSolvers/ValueIteration.py
@@ -1,7 +1,14 @@
 """Classical Value Iteration
 Performs full Bellman Backup on a given s,a pair by sweeping through the state space
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from .MDPSolver import MDPSolver
 from rlpy.Tools import hhmmss, deltaT, className, clock, l_norm

--- a/rlpy/MDPSolvers/ValueIteration.py
+++ b/rlpy/MDPSolvers/ValueIteration.py
@@ -1,7 +1,6 @@
 """Classical Value Iteration
 Performs full Bellman Backup on a given s,a pair by sweeping through the state space
 """
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import

--- a/rlpy/MDPSolvers/ValueIteration.py
+++ b/rlpy/MDPSolvers/ValueIteration.py
@@ -2,6 +2,7 @@
 Performs full Bellman Backup on a given s,a pair by sweeping through the state space
 """
 
+from builtins import range
 from .MDPSolver import MDPSolver
 from rlpy.Tools import hhmmss, deltaT, className, clock, l_norm
 import numpy as np
@@ -68,7 +69,7 @@ class ValueIteration(MDPSolver):
             prev_weight_vec = self.representation.weight_vec.copy()
 
             # Sweep The State Space
-            for i in xrange(no_of_states):
+            for i in range(no_of_states):
 
                 s = self.representation.stateID2state(i)
 

--- a/rlpy/MDPSolvers/__init__.py
+++ b/rlpy/MDPSolvers/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from .ValueIteration import ValueIteration
 from .PolicyIteration import PolicyIteration
 from .TrajectoryBasedValueIteration import TrajectoryBasedValueIteration

--- a/rlpy/Policies/FixedPolicy.py
+++ b/rlpy/Policies/FixedPolicy.py
@@ -1,5 +1,7 @@
 """Fixed policy. Encodes fixed policies for particular domains."""
+from __future__ import print_function
 
+from builtins import range
 from rlpy.Tools import vec2id
 from .Policy import Policy
 import numpy as np
@@ -69,13 +71,13 @@ class FixedPolicy(Policy):
     def pi2(self, s, terminal, p_actions):
         domain = self.representation.domain
         if not className(domain) in self.supportedDomains:
-            print "ERROR: There is no fixed policy defined for %s" % className(domain)
+            print("ERROR: There is no fixed policy defined for %s" % className(domain))
             return None
 
         if className(domain) == 'GridWorld':
             # Actions are Up, Down, Left, Right
             if not self.policyName in self.gridWorldPolicyNames:
-                print "Error: There is no GridWorld policy with name %s" % self.policyName
+                print("Error: There is no GridWorld policy with name %s" % self.policyName)
                 return None
 
             if self.policyName == 'cw_circle':
@@ -97,7 +99,7 @@ class FixedPolicy(Policy):
                     elif self.curAction == 2:  # left
                         self.curAction = 0
                     else:
-                        print 'Something terrible happened...got an invalid action on GridWorld Fixed Policy'
+                        print('Something terrible happened...got an invalid action on GridWorld Fixed Policy')
     #                 self.curAction = self.curAction % domain.actions_num
             elif self.policyName == 'ccw_circle':
                 # Cycle through actions, starting with 0, causing agent to go
@@ -117,12 +119,12 @@ class FixedPolicy(Policy):
                     elif self.curAction == 1:  # down
                         self.curAction = 3
                     else:
-                        print 'Something terrible happened...got an invalid action on GridWorld Fixed Policy'
+                        print('Something terrible happened...got an invalid action on GridWorld Fixed Policy')
     #                 self.curAction = self.curAction % domain.actions_num
 
             else:
-                print "Error: No policy defined with name %s, but listed in gridWorldPolicyNames" % self.policyName
-                print "You need to create a switch statement for the policy name above, or remove it from gridWorldPolicyNames"
+                print("Error: No policy defined with name %s, but listed in gridWorldPolicyNames" % self.policyName)
+                print("You need to create a switch statement for the policy name above, or remove it from gridWorldPolicyNames")
                 return None
             return self.curAction
 
@@ -214,7 +216,7 @@ class FixedPolicy(Policy):
             # Default action is hold
             actions = np.ones(len(agents), dtype=np.integer) * 4
             planned_agents_num = min(len(agents), len(targets))
-            for i in xrange(planned_agents_num):
+            for i in range(planned_agents_num):
                 # Find cloasest zone (manhattan) to the corresponding target
                 target = targets[i, :]
                 distances = np.sum(
@@ -256,8 +258,8 @@ class FixedPolicy(Policy):
         if className(domain) == 'PST':
             # One stays at comm, n-1 stay at target area. Whenever fuel is
             # lower than reaching the base the move back
-            print s
+            print(s)
             s = domain.state2Struct(s)
             uavs = domain.NUM_UAV
-            print s
+            print(s)
             return vec2id(np.zeros(uavs), np.ones(uavs) * 3)

--- a/rlpy/Policies/FixedPolicy.py
+++ b/rlpy/Policies/FixedPolicy.py
@@ -1,6 +1,12 @@
 """Fixed policy. Encodes fixed policies for particular domains."""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Tools import vec2id
 from .Policy import Policy

--- a/rlpy/Policies/Policy.py
+++ b/rlpy/Policies/Policy.py
@@ -1,9 +1,12 @@
 """Policy base class"""
+from __future__ import print_function
 
+from builtins import object
 from rlpy.Tools import className, discrete_sample
 import numpy as np
 import logging
 from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = ["Alborz Geramifard", "Robert H. Klein", "Christoph Dann",
@@ -92,15 +95,13 @@ class Policy(object):
 
     def printAll(self):
         """ Prints all class information to console. """
-        print className(self)
-        print '======================================='
-        for property, value in vars(self).iteritems():
-            print property, ": ", value
+        print(className(self))
+        print('=======================================')
+        for property, value in vars(self).items():
+            print(property, ": ", value)
 
 
-class DifferentiablePolicy(Policy):
-
-    __metaclass__ = ABCMeta
+class DifferentiablePolicy(with_metaclass(ABCMeta, Policy)):
 
     def pi(self, s, terminal, p_actions):
         """Sample action from policy"""

--- a/rlpy/Policies/Policy.py
+++ b/rlpy/Policies/Policy.py
@@ -1,6 +1,11 @@
 """Policy base class"""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 from rlpy.Tools import className, discrete_sample
 import numpy as np

--- a/rlpy/Policies/SwimmerPolicy.py
+++ b/rlpy/Policies/SwimmerPolicy.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from .Policy import Policy
 
 import numpy as np

--- a/rlpy/Policies/UniformRandom.py
+++ b/rlpy/Policies/UniformRandom.py
@@ -1,5 +1,7 @@
 """Uniform Random policy"""
+from __future__ import division
 
+from past.utils import old_div
 from .Policy import Policy
 import numpy as np
 
@@ -21,7 +23,7 @@ class UniformRandom(Policy):
         super(UniformRandom, self).__init__(representation, seed)
     
     def prob(self, s, terminal, p_actions):
-        p = np.ones(len(p_actions)) / len(p_actions)
+        p = old_div(np.ones(len(p_actions)), len(p_actions))
         return p
 
     def pi(self, s, terminal, p_actions):

--- a/rlpy/Policies/UniformRandom.py
+++ b/rlpy/Policies/UniformRandom.py
@@ -1,6 +1,12 @@
 """Uniform Random policy"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Policy import Policy
 import numpy as np

--- a/rlpy/Policies/__init__.py
+++ b/rlpy/Policies/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from .eGreedy import eGreedy
 from .UniformRandom import UniformRandom
 from .gibbs import GibbsPolicy

--- a/rlpy/Policies/eGreedy.py
+++ b/rlpy/Policies/eGreedy.py
@@ -1,5 +1,7 @@
 """epsilon-Greedy Policy"""
+from __future__ import division
 
+from past.utils import old_div
 from .Policy import Policy
 import numpy as np
 
@@ -48,13 +50,13 @@ class eGreedy(Policy):
                 return self.random_state.choice(b_actions)
 
     def prob(self, s, terminal, p_actions):
-        p = np.ones(len(p_actions)) / len(p_actions)
+        p = old_div(np.ones(len(p_actions)), len(p_actions))
         p *= self.epsilon
         b_actions = self.representation.bestActions(s, terminal, p_actions)
         if self.forcedDeterministicAmongBestActions:
             p[b_actions[0]] += (1 - self.epsilon)
         else:
-            p[b_actions] += (1 - self.epsilon) / len(b_actions)
+            p[b_actions] += old_div((1 - self.epsilon), len(b_actions))
         return p
 
     def turnOffExploration(self):

--- a/rlpy/Policies/eGreedy.py
+++ b/rlpy/Policies/eGreedy.py
@@ -1,6 +1,12 @@
 """epsilon-Greedy Policy"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Policy import Policy
 import numpy as np

--- a/rlpy/Policies/gibbs.py
+++ b/rlpy/Policies/gibbs.py
@@ -1,6 +1,11 @@
 """Gibbs policy"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from .Policy import DifferentiablePolicy
 import numpy as np

--- a/rlpy/Policies/gibbs.py
+++ b/rlpy/Policies/gibbs.py
@@ -1,5 +1,7 @@
 """Gibbs policy"""
+from __future__ import division
 
+from past.utils import old_div
 from .Policy import DifferentiablePolicy
 import numpy as np
 
@@ -35,6 +37,6 @@ class GibbsPolicy(DifferentiablePolicy):
         n = self.representation.features_num
         v = np.exp(np.dot(self.representation.weight_vec.reshape(-1, n), phi))
         v[v > 1e50] = 1e50
-        r = v / v.sum()
+        r = old_div(v, v.sum())
         assert not np.any(np.isnan(r))
         return r

--- a/rlpy/Representations/BEBF.py
+++ b/rlpy/Representations/BEBF.py
@@ -1,6 +1,14 @@
 """Bellman-Error Basis Function Representation."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 #from rlpy.Tools import
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 import numpy as np
 from .Representation import Representation

--- a/rlpy/Representations/BEBF.py
+++ b/rlpy/Representations/BEBF.py
@@ -1,6 +1,7 @@
 """Bellman-Error Basis Function Representation."""
 
 #from rlpy.Tools import
+from builtins import range
 import numpy as np
 from .Representation import Representation
 from rlpy.Tools import svm
@@ -131,7 +132,7 @@ class BEBF(Representation):
         addedFeature = False
         # PLACEHOLDER for norm of function
         norm = max(abs(td_errors))  # Norm of function
-        for j in xrange(self.maxBatchDiscovery):
+        for j in range(self.maxBatchDiscovery):
             self.features.append(self.getFunctionApproximation(s, td_errors))
             if norm > self.batchThreshold:
                 self.addNewWeight()

--- a/rlpy/Representations/Fourier.py
+++ b/rlpy/Representations/Fourier.py
@@ -1,5 +1,8 @@
 """Fourier representation"""
+from __future__ import division
 
+from builtins import map
+from past.utils import old_div
 from .Representation import Representation
 from numpy import indices, pi, cos, dot
 from numpy.linalg import norm
@@ -34,9 +37,9 @@ class Fourier(Representation):
         self.features_num = self.coeffs.shape[0]
 
         if scaling:
-            coeff_norms = numpy.array(map(norm, self.coeffs))
+            coeff_norms = numpy.array(list(map(norm, self.coeffs)))
             coeff_norms[0] = 1.0
-            self.alpha_scale = numpy.tile(1.0/coeff_norms, (domain.actions_num,))
+            self.alpha_scale = numpy.tile(old_div(1.0,coeff_norms), (domain.actions_num,))
         else:
             self.alpha_scale = 1.0
 
@@ -45,7 +48,7 @@ class Fourier(Representation):
     def phi_nonTerminal(self, s):
         # normalize the state
         s_min, s_max = self.domain.statespace_limits.T
-        norm_state = (s - s_min) / (s_max - s_min)
+        norm_state = old_div((s - s_min), (s_max - s_min))
         return cos(pi * dot(self.coeffs, norm_state))
 
     def featureType(self):

--- a/rlpy/Representations/Fourier.py
+++ b/rlpy/Representations/Fourier.py
@@ -1,6 +1,12 @@
 """Fourier representation"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import map
 from past.utils import old_div
 from .Representation import Representation

--- a/rlpy/Representations/IncrementalTabular.py
+++ b/rlpy/Representations/IncrementalTabular.py
@@ -1,5 +1,12 @@
 """Incrementally expanded Tabular Representation"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from .Representation import Representation
 import numpy as np
 from copy import deepcopy

--- a/rlpy/Representations/IndependentDiscretization.py
+++ b/rlpy/Representations/IndependentDiscretization.py
@@ -1,5 +1,7 @@
 """Independent Discretization"""
+from __future__ import print_function
 
+from builtins import str
 from .Representation import Representation
 import numpy as np
 
@@ -52,7 +54,7 @@ class IndependentDiscretization(Representation):
             index_in_dim = feat_id
             if dim != 0:
                 index_in_dim = feat_id - self.maxFeatureIDperDimension[dim - 1]
-            print self.domain.DimNames[dim]
+            print(self.domain.DimNames[dim])
             f_name = self.domain.DimNames[dim] + '=' + str(index_in_dim)
 
     def featureType(self):

--- a/rlpy/Representations/IndependentDiscretization.py
+++ b/rlpy/Representations/IndependentDiscretization.py
@@ -1,6 +1,13 @@
 """Independent Discretization"""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from .Representation import Representation
 import numpy as np

--- a/rlpy/Representations/IndependentDiscretizationCompactBinary.py
+++ b/rlpy/Representations/IndependentDiscretizationCompactBinary.py
@@ -1,5 +1,13 @@
 """Independent Discretization with compact handling of binary features."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from .Representation import Representation
 import numpy as np
 from copy import copy

--- a/rlpy/Representations/KernelizediFDD.py
+++ b/rlpy/Representations/KernelizediFDD.py
@@ -1,5 +1,12 @@
 """Kernelized Incremental Feature Dependency Discovery"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import numpy as np
 from .Representation import Representation
 from itertools import combinations
@@ -101,7 +108,7 @@ class KernelizediFDD(Representation):
         l.sort(key=key)
         for i in l:
             f = self.features[i]
-            print "{:>5} {:>20}".format(i, f)
+            print("{:>5} {:>20}".format(i, f))
 
     def plot_1d_features(self, dimension_idx=None):
         """Creates a plot for each specified dimension of the state space and shows
@@ -116,7 +123,7 @@ class KernelizediFDD(Representation):
         elif idx is None:
             idx = self.domain.continuous_dims
 
-        feat_list = range(self.features_num)
+        feat_list = list(range(self.features_num))
         key = lambda x: (
             len(self.features[x].base_ids),
             tuple(self.features[x].dim),
@@ -166,7 +173,7 @@ class KernelizediFDD(Representation):
             idx = [d1, d2]
         idx.sort()
 
-        feat_list = range(self.features_num)
+        feat_list = list(range(self.features_num))
         key = lambda x: (
             len(self.features[x].base_ids),
             tuple(self.features[x].dim),
@@ -206,8 +213,8 @@ class KernelizediFDD(Representation):
                         "Feature Dimensions {} and {}".format(cur_i, cur_j))
             if cur_i in idx and cur_j in idx:
                 Z = np.zeros_like(X)
-                for m in xrange(100):
-                    for n in xrange(100):
+                for m in range(100):
+                    for n in range(100):
                         x = np.zeros(self.domain.statespace_limits.shape[0])
                         x[cur_i] = X[m, n]
                         x[cur_j] = Y[m, n]
@@ -233,7 +240,7 @@ class KernelizediFDD(Representation):
             idx = [d1, d2]
         idx.sort()
 
-        feat_list = range(self.features_num)
+        feat_list = list(range(self.features_num))
         key = lambda x: (
             len(self.features[x].base_ids),
             tuple(self.features[x].dim),
@@ -267,7 +274,7 @@ class KernelizediFDD(Representation):
     def phi_nonTerminal(self, s):
         out = np.zeros(self.features_num)
         if not self.sparsify:
-            for i in xrange(self.features_num):
+            for i in range(self.features_num):
                 out[i] = self.features[i].output(s)
         else:
             # get all base feature values and check if they are activated
@@ -306,7 +313,7 @@ class KernelizediFDD(Representation):
     def phi_raw(self, s, terminal):
         assert(terminal is False)
         out = np.zeros(self.features_num)
-        for i in xrange(self.features_num):
+        for i in range(self.features_num):
             out[i] = self.features[i].output(s)
         return out
 
@@ -330,7 +337,7 @@ class KernelizediFDD(Representation):
                 closest_neighbor[j] = max(closest_neighbor[j], phi_s_unnorm[i])
 
         # add new base features for all dimension not regarded
-        for j in xrange(len(s)):
+        for j in range(len(s)):
             if active_dimensions[j] < self.max_active_base_feat and (closest_neighbor[j] < self.max_base_feat_sim or active_dimensions[j] < 1):
                 active_indices.append(self.add_base_feature(s, j, Q=Q))
                 discovered += 1
@@ -340,7 +347,7 @@ class KernelizediFDD(Representation):
             phi_s = self.phi(s, terminal)
         la = len(active_indices)
         if la * (la - 1) < len(self.candidates):
-            for ind, cand in self.candidates.items():
+            for ind, cand in list(self.candidates.items()):
                 g, h = ind
                 rel = self.update_relevance_stat(
                     cand,
@@ -392,8 +399,8 @@ class KernelizediFDD(Representation):
         candidate.activation_count += phi_s[index1] ** 2 * phi_s[index2] ** 2
         if candidate.activation_count == 0.:
             return 0.
-        rel = np.abs(candidate.td_error_sum) / \
-            np.sqrt(candidate.activation_count)
+        rel = old_div(np.abs(candidate.td_error_sum), \
+            np.sqrt(candidate.activation_count))
         return rel
 
     def add_base_feature(self, center, dim, Q):
@@ -414,10 +421,10 @@ class KernelizediFDD(Representation):
 
         # add combinations with all existing features as candidates
         new_cand = {(f, self.features_num): Candidate(f, self.features_num)
-                    for f in xrange(self.features_num) if dim not in self.features[f].dim}
+                    for f in range(self.features_num) if dim not in self.features[f].dim}
 
         self.candidates.update(new_cand)
-        for f, _ in new_cand.keys():
+        for f, _ in list(new_cand.keys()):
             self.base_id_sets.add(new_f.base_ids | self.features[f].base_ids)
         self.features_num += 1
 
@@ -462,10 +469,10 @@ class KernelizediFDD(Representation):
         del self.candidates[(index1, index2)]
 
         # add new candidates
-        new_cand = {(f, self.features_num): Candidate(f, self.features_num) for f in xrange(self.features_num)
+        new_cand = {(f, self.features_num): Candidate(f, self.features_num) for f in range(self.features_num)
                     if (self.features[f].base_ids | new_base_ids) not in self.base_id_sets
                     and len(frozenset(self.features[f].dim) & frozenset(new_dim)) == 0}
-        for c, _ in new_cand.keys():
+        for c, _ in list(new_cand.keys()):
             self.base_id_sets.add(new_base_ids | self.features[c].base_ids)
         self.candidates.update(new_cand)
         self.logger.debug(
@@ -488,7 +495,7 @@ class KernelizediFDD(Representation):
 
 
 try:
-    from kernels import *
+    from .kernels import *
 except ImportError:
-    print "C-Extension for kernels not available, expect slow runtime"
-    from slow_kernels import *
+    print("C-Extension for kernels not available, expect slow runtime")
+    from .slow_kernels import *

--- a/rlpy/Representations/KernelizediFDD.py
+++ b/rlpy/Representations/KernelizediFDD.py
@@ -2,7 +2,11 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/rlpy/Representations/LocalBases.py
+++ b/rlpy/Representations/LocalBases.py
@@ -6,6 +6,10 @@ samples)
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 from .Representation import Representation

--- a/rlpy/Representations/LocalBases.py
+++ b/rlpy/Representations/LocalBases.py
@@ -3,15 +3,20 @@ Representations which use local bases function (e.g. kernels) distributed
 in the statespace according to some scheme (e.g. grid, random, on previous
 samples)
 """
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
+from past.utils import old_div
 from .Representation import Representation
 import numpy as np
 from rlpy.Tools.GeneralTools import addNewElementForAllActions
 import matplotlib.pyplot as plt
 try:
-    from kernels import batch
+    from .kernels import batch
 except ImportError:
-    from slow_kernels import batch
-    print "C-Extensions for kernels not available, expect slow runtime"
+    from .slow_kernels import batch
+    print("C-Extensions for kernels not available, expect slow runtime")
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = ["Alborz Geramifard", "Robert H. Klein", "Christoph Dann",
@@ -67,7 +72,7 @@ class LocalBases(Representation):
             # just take the first two dimensions
             d1, d2 = self.domain.continuous_dims[:2]
         plt.figure("Feature Dimensions {} and {}".format(d1, d2))
-        for i in xrange(self.centers.shape[0]):
+        for i in range(self.centers.shape[0]):
             plt.plot([self.centers[i, d1]],
                      [self.centers[i, d2]], "r", marker="x")
         plt.draw()
@@ -92,8 +97,8 @@ class NonparametricLocalBases(LocalBases):
         
         """
         self.max_similarity = max_similarity
-        self.common_width = (domain.statespace_limits[:, 1]
-                             - domain.statespace_limits[:, 0]) / resolution
+        self.common_width = old_div((domain.statespace_limits[:, 1]
+                             - domain.statespace_limits[:, 0]), resolution)
         self.features_num = 0
         super(
             NonparametricLocalBases,
@@ -168,11 +173,11 @@ class RandomLocalBases(LocalBases):
         self.init_randomization()
     
     def init_randomization(self):
-        for i in xrange(self.features_num):
-            for d in xrange(len(self.dim_widths)):
+        for i in range(self.features_num):
+            for d in range(len(self.dim_widths)):
                 self.centers[i, d] = self.random_state.uniform(
                     self.domain.statespace_limits[d, 0],
                     self.domain.statespace_limits[d, 1])
                 self.widths[i, d] = self.random_state.uniform(
-                    self.dim_widths[d] / self.resolution_max,
-                    self.dim_widths[d] / self.resolution_min)
+                    old_div(self.dim_widths[d], self.resolution_max),
+                    old_div(self.dim_widths[d], self.resolution_min))

--- a/rlpy/Representations/OMPTD.py
+++ b/rlpy/Representations/OMPTD.py
@@ -1,7 +1,12 @@
 """OMP-TD implementation based on ICML 2012 paper of Wakefield and Parr."""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/rlpy/Representations/OMPTD.py
+++ b/rlpy/Representations/OMPTD.py
@@ -1,5 +1,10 @@
 """OMP-TD implementation based on ICML 2012 paper of Wakefield and Parr."""
+from __future__ import division
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 from .Representation import Representation
 import numpy as np
 from .iFDD import iFDD
@@ -82,8 +87,8 @@ class OMPTD(Representation):
         self.fillBag()
         self.totalFeatureSize = self.bagSize
         # Add initial features to the selected list
-        self.selectedFeatures = range(
-            self.initial_representation.features_num)
+        self.selectedFeatures = list(range(
+            self.initial_representation.features_num))
         # Array of indicies of features that have not been selected
         self.remainingFeatures = np.arange(self.features_num, self.bagSize)
 
@@ -102,9 +107,9 @@ class OMPTD(Representation):
         to its representation.
         
         """
-        print "Remaining Items in the feature bag:"
+        print("Remaining Items in the feature bag:")
         for f in self.remainingFeatures:
-            print "%d: %s" % (f, str(sorted(list(self.iFDD.getFeature(f).f_set))))
+            print("%d: %s" % (f, str(sorted(list(self.iFDD.getFeature(f).f_set)))))
 
     def calculateFullPhiNormalized(self, states):
         """
@@ -123,12 +128,12 @@ class OMPTD(Representation):
                 self.fullphi[i, :] = self.iFDD.phi_nonTerminal(s)
         self.domain.state = o_s
         # Normalize features
-        for f in xrange(self.totalFeatureSize):
+        for f in range(self.totalFeatureSize):
             phi_f = self.fullphi[:, f]
             norm_phi_f = np.linalg.norm(phi_f)    # L2-Norm of phi_f
             if norm_phi_f == 0:
                 norm_phi_f = 1          # This helps to avoid divide by zero
-            self.fullphi[:, f] = phi_f / norm_phi_f
+            self.fullphi[:, f] = old_div(phi_f, norm_phi_f)
 
     def batchDiscover(self, td_errors, phi, states):
         """
@@ -175,7 +180,7 @@ class OMPTD(Representation):
         self.logger.debug("OMPTD Batch: Max Relevance = %0.3f" % max_relevance)
         added_feature = False
         to_be_deleted = []  # Record the indices of items to be removed
-        for j in xrange(min(self.maxBatchDiscovery, len(relevances))):
+        for j in range(min(self.maxBatchDiscovery, len(relevances))):
             max_index = sortedIndices[j]
             f = self.remainingFeatures[max_index]
             relevance = relevances[max_index]
@@ -207,7 +212,7 @@ class OMPTD(Representation):
         # We store the dimension corresponding to each feature so we avoid
         # adding pairs of features in the same dimension
         level_1_features_dim = {}
-        for i in xrange(self.initial_representation.features_num):
+        for i in range(self.initial_representation.features_num):
             level_1_features_dim[i] = np.array(
                 [self.initial_representation.getDimNumber(i)])
             # print i,level_1_features_dim[i]

--- a/rlpy/Representations/RBF.py
+++ b/rlpy/Representations/RBF.py
@@ -1,5 +1,8 @@
 """Radial Basis Function Representation"""
+from __future__ import division
 
+from builtins import range
+from past.utils import old_div
 from rlpy.Tools import perms
 from .Representation import Representation
 import numpy as np
@@ -65,7 +68,7 @@ class RBF(Representation):
         if state_dimensions is not None:
             self.dims = len(state_dimensions)
         else:  # just consider all dimensions
-            state_dimensions = range(domain.state_space_dims)
+            state_dimensions = list(range(domain.state_space_dims))
             self.dims = domain.state_space_dims
 
         if self.grid_bins is not None:
@@ -96,15 +99,15 @@ class RBF(Representation):
             self.rbfs_sigma = np.zeros((self.num_rbfs, self.dims))
             dim_widths = (self.domain.statespace_limits[self.state_dimensions, 1])
 
-            for i in xrange(self.num_rbfs):
+            for i in range(self.num_rbfs):
                 for d in self.state_dimensions:
                     self.rbfs_mu[i, d] = self.random_state.uniform(
                         self.domain.statespace_limits[d, 0],
                         self.domain.statespace_limits[d, 1])
                     self.rbfs_sigma[i,
                                     d] = self.random_state.uniform(
-                        dim_widths[d] / self.resolution_max,
-                        dim_widths[d] / self.resolution_min)
+                        old_div(dim_widths[d], self.resolution_max),
+                        old_div(dim_widths[d], self.resolution_min))
 
     def phi_nonTerminal(self, s):
         F_s = np.ones(self.features_num)
@@ -112,7 +115,7 @@ class RBF(Representation):
             s = s[self.state_dimensions]
 
         exponent = np.sum(
-            0.5 * ((s - self.rbfs_mu) / self.rbfs_sigma) ** 2,
+            0.5 * (old_div((s - self.rbfs_mu), self.rbfs_sigma)) ** 2,
             axis=1)
         if self.const_feature:
             F_s[:-1] = np.exp(-exponent)
@@ -160,7 +163,7 @@ class RBF(Representation):
         else:
             rbfs_num = np.prod(bins_per_dimension[:] - 1)
         all_centers = []
-        for d in xrange(dims):
+        for d in range(dims):
             centers = np.linspace(domain.statespace_limits[d, 0],
                                   domain.statespace_limits[d, 1],
                                   bins_per_dimension[d] + 1)

--- a/rlpy/Representations/RBF.py
+++ b/rlpy/Representations/RBF.py
@@ -1,6 +1,12 @@
 """Radial Basis Function Representation"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 from rlpy.Tools import perms

--- a/rlpy/Representations/Representation.py
+++ b/rlpy/Representations/Representation.py
@@ -1,5 +1,10 @@
 """Representation base class."""
+from __future__ import division
+from __future__ import print_function
 
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import logging
 from copy import deepcopy
 from rlpy.Tools import className, addNewElementForAllActions
@@ -309,13 +314,13 @@ class Representation(object):
         """
         self.bins_per_dim = np.zeros(domain.state_space_dims, np.uint16)
         self.binWidth_per_dim = np.zeros(domain.state_space_dims)
-        for d in xrange(domain.state_space_dims):
+        for d in range(domain.state_space_dims):
             if d in domain.continuous_dims:
                 self.bins_per_dim[d] = discretization
             else:
                 self.bins_per_dim[d] = domain.statespace_limits[d, 1] - \
                     domain.statespace_limits[d, 0]
-            self.binWidth_per_dim[d] = (domain.statespace_limits[d,1] - domain.statespace_limits[d, 0]) / (self.bins_per_dim[d] * 1.)
+            self.binWidth_per_dim[d] = old_div((domain.statespace_limits[d,1] - domain.statespace_limits[d, 0]), (self.bins_per_dim[d] * 1.))
 
     def binState(self, s):
         """
@@ -493,7 +498,7 @@ class Representation(object):
         else:
             phi_s_a = np.zeros((p, n * a_num), dtype=all_phi_s.dtype)
 
-        for i in xrange(a_num):
+        for i in range(a_num):
             rows = np.where(all_actions == i)[0]
             if len(rows):
                 phi_s_a[rows, i * n:(i + 1) * n] = all_phi_s[rows,:]
@@ -594,7 +599,7 @@ class Representation(object):
         if hasFunction(self.domain, 'expectedStep'):
             p, r, ns, t, p_actions = self.domain.expectedStep(s, a)
             Q = 0
-            for j in xrange(len(p)):
+            for j in range(len(p)):
                 if policy is None:
                     Q += p[j, 0] * (r[j, 0] + discount_factor * self.V(ns[j,:], t[j,:], p_actions[j]))
                 else:
@@ -623,13 +628,13 @@ class Representation(object):
                         (ns_samples, self.domain.state_space_dims))
                     rewards = np.empty(ns_samples)
                     # next states per samples initial state
-                    ns_samples_ = ns_samples / \
-                        self.continuous_state_starting_samples
-                    for i in xrange(self.continuous_state_starting_samples):
+                    ns_samples_ = old_div(ns_samples, \
+                        self.continuous_state_starting_samples)
+                    for i in range(self.continuous_state_starting_samples):
                         # sample a random state within the grid corresponding
                         # to input s
                         new_s = s.copy()
-                        for d in xrange(self.domain.state_space_dims):
+                        for d in range(self.domain.state_space_dims):
                             w = self.binWidth_per_dim[d]
                             # Sample each dimension of the new_s within the
                             # cell
@@ -650,9 +655,9 @@ class Representation(object):
                 # print "USED CACHED"
                 next_states, rewards = cacheHit
             if policy is None:
-                Q = np.mean([rewards[i] + discount_factor * self.V(next_states[i,:]) for i in xrange(ns_samples)])
+                Q = np.mean([rewards[i] + discount_factor * self.V(next_states[i,:]) for i in range(ns_samples)])
             else:
-                Q = np.mean([rewards[i] + discount_factor * self.Q(next_states[i,:], policy.pi(next_states[i,:])) for i in xrange(ns_samples)])
+                Q = np.mean([rewards[i] + discount_factor * self.Q(next_states[i,:], policy.pi(next_states[i,:])) for i in range(ns_samples)])
         return Q
 
     def Qs_oneStepLookAhead(self, s, ns_samples, policy=None):
@@ -734,7 +739,7 @@ class Representation(object):
         s = np.array(id2vec(s_id, self.bins_per_dim))
 
         # Find the value corresponding to each bin number
-        for d in xrange(self.domain.state_space_dims):
+        for d in range(self.domain.state_space_dims):
             s[d] = bin2state(s[d], self.bins_per_dim[d], self.domain.statespace_limits[d,:])
 
         if len(self.domain.continuous_dims) == 0:
@@ -755,7 +760,7 @@ class Representation(object):
         :return: The nearest state *s* which is captured by the discretization.
         """
         s_normalized = s.copy()
-        for d in xrange(self.domain.state_space_dims):
+        for d in range(self.domain.state_space_dims):
             s_normalized[d] = closestDiscretization(s[d], self.bins_per_dim[d], self.domain.statespace_limits[d,:])
         return s_normalized
 
@@ -774,7 +779,7 @@ class Representation(object):
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
-        for k, v in self.__dict__.items():
+        for k, v in list(self.__dict__.items()):
             if k is "logger":
                 continue
             setattr(result, k, deepcopy(v, memo))

--- a/rlpy/Representations/Representation.py
+++ b/rlpy/Representations/Representation.py
@@ -1,7 +1,12 @@
 """Representation base class."""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from builtins import object
 from past.utils import old_div

--- a/rlpy/Representations/Tabular.py
+++ b/rlpy/Representations/Tabular.py
@@ -1,5 +1,13 @@
 """Tabular representation"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from .Representation import Representation
 import numpy as np
 

--- a/rlpy/Representations/TileCoding.py
+++ b/rlpy/Representations/TileCoding.py
@@ -1,5 +1,10 @@
 """Tile Coding Representation"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import range
+from past.utils import old_div
 import numpy as np
 from .Representation import Representation
 
@@ -95,8 +100,8 @@ class TileCoding(Representation):
                     resolution_matrix[i, d] = resolutions[i]
         resolution_matrix = resolution_matrix.astype("float")
         resolution_matrix[resolution_matrix == 0] = 1e-50
-        self.scaling_matrix = (self.domain.statespace_limits[:, 1] -
-                               self.domain.statespace_limits[:, 0]) / resolution_matrix
+        self.scaling_matrix = old_div((self.domain.statespace_limits[:, 1] -
+                               self.domain.statespace_limits[:, 0]), resolution_matrix)
 
         # now only hashing stuff
         self.seed = seed
@@ -114,19 +119,19 @@ class TileCoding(Representation):
         self.init_randomization()
 
     def init_randomization(self):
-        self.R = self.random_state.randint(self.BIG_INT / 4,
+        self.R = self.random_state.randint(old_div(self.BIG_INT, 4),
             size=self.features_num).astype(np.int)
 
         if self.safety == "none":
             try:
-                import hashing as h
+                from . import hashing as h
                 f = lambda self, A: h.physical_addr(A, self.R, self.check_data,
                                                     self.counts)[0]
                 self._physical_addr = type(TileCoding._physical_addr)(f, self, TileCoding)
-                print "Use cython extension for TileCoding hashing trick"
+                print("Use cython extension for TileCoding hashing trick")
             except Exception as e:
-                print e
-                print "Cython extension for TileCoding hashing trick not available"
+                print(e)
+                print("Cython extension for TileCoding hashing trick not available")
         
     def phi_nonTerminal(self, s):
 
@@ -136,8 +141,8 @@ class TileCoding(Representation):
             # first dimension is used to avoid collisions between different
             # tilings
             sn[0] = e
-            sn[1:] = (s - self.domain.statespace_limits[:, 0]) / \
-                self.scaling_matrix[e]
+            sn[1:] = old_div((s - self.domain.statespace_limits[:, 0]), \
+                self.scaling_matrix[e])
             for i in range(n_t):
                 # compute "virtual" address
                 A = sn - np.mod(sn - i, n_t)
@@ -184,8 +189,8 @@ class TileCoding(Representation):
             self.collisions += 1
             return h1
         else:
-            h2 = 1 + 2 * self._hash(A, max=self.BIG_INT / 4)
-            for i in xrange(self.features_num):
+            h2 = 1 + 2 * self._hash(A, max=old_div(self.BIG_INT, 4))
+            for i in range(self.features_num):
                 h1 = (h1 + h2) % self.features_num
                 if self.counts[h1] == 0 or np.all(self.check_data[h1] == check_val):
                     self.check_data[h1] = check_val

--- a/rlpy/Representations/TileCoding.py
+++ b/rlpy/Representations/TileCoding.py
@@ -2,7 +2,12 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
+from builtins import super
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 import numpy as np

--- a/rlpy/Representations/__init__.py
+++ b/rlpy/Representations/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from .Tabular import Tabular
 from .IncrementalTabular import IncrementalTabular
 from .IndependentDiscretization import IndependentDiscretization

--- a/rlpy/Representations/iFDD.py
+++ b/rlpy/Representations/iFDD.py
@@ -1,8 +1,13 @@
 """Incremental Feature Dependency Discovery"""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 # iFDD implementation based on ICML 2011 paper
 
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/rlpy/Representations/iFDD.py
+++ b/rlpy/Representations/iFDD.py
@@ -1,6 +1,12 @@
 """Incremental Feature Dependency Discovery"""
+from __future__ import division
+from __future__ import print_function
 # iFDD implementation based on ICML 2011 paper
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 from copy import deepcopy
 import numpy as np
 
@@ -314,7 +320,7 @@ class iFDD(Representation):
         # Check for discovery
 
         if self.random_state.rand() < self.iFDDPlus:
-            relevance = abs(potential.cumtderr) / np.sqrt(potential.count)
+            relevance = old_div(abs(potential.cumtderr), np.sqrt(potential.count))
         else:
             relevance = potential.cumabstderr
 
@@ -348,7 +354,7 @@ class iFDD(Representation):
         self.hashed_s = None
 
     def addInitialFeatures(self):
-        for i in xrange(self.initial_representation.features_num):
+        for i in range(self.initial_representation.features_num):
             feature = iFDD_feature(i)
             # shout(self,self.iFDD_features[frozenset([i])].index)
             self.iFDD_features[frozenset([i])] = feature
@@ -372,13 +378,13 @@ class iFDD(Representation):
         # print "IN IFDD, New Feature = %d => Total Features = %d" % (feature.index, self.features_num)
         # Update the sorted list of features
         # priority is 1/number of initial features corresponding to the feature
-        priority = 1 / (len(potential.f_set) * 1.)
+        priority = old_div(1, (len(potential.f_set) * 1.))
         self.sortediFDDFeatures.push(priority, feature)
 
         # If you use cache, you should invalidate entries that their initial
         # set contains the set corresponding to the new feature
         if self.useCache:
-            for initialActiveFeatures in self.cache.keys():
+            for initialActiveFeatures in list(self.cache.keys()):
                 if initialActiveFeatures.issuperset(feature.f_set):
                     if self.sparsify:
                         self.cache.pop(initialActiveFeatures)
@@ -403,7 +409,7 @@ class iFDD(Representation):
         p = len(td_errors)  # Number of samples
         counts = np.zeros((n, n))
         relevances = np.zeros((n, n))
-        for i in xrange(p):
+        for i in range(p):
             phiphiT = np.outer(phi[i, :], phi[i, :])
             if self.iFDDPlus:
                 relevances += phiphiT * td_errors[i]
@@ -449,7 +455,7 @@ class iFDD(Representation):
             "iFDD Batch: Max Relevance = {0:g}".format(max_relevance))
         added_feature = False
         new_features = 0
-        for j in xrange(len(relevances)):
+        for j in range(len(relevances)):
             if new_features >= maxDiscovery:
                 break
             max_index = sortedIndices[j]
@@ -475,35 +481,35 @@ class iFDD(Representation):
         )
 
     def showFeatures(self):
-        print "Features:"
-        print "-" * 30
-        print " index\t| f_set\t| p1\t| p2\t | Weights (per action)"
-        print "-" * 30
+        print("Features:")
+        print("-" * 30)
+        print(" index\t| f_set\t| p1\t| p2\t | Weights (per action)")
+        print("-" * 30)
         for feature in reversed(self.sortediFDDFeatures.toList()):
         # for feature in self.iFDD_features.itervalues():
             # print " %d\t| %s\t| %s\t| %s\t| %s" %
             # (feature.index,str(list(feature.f_set)),feature.p1,feature.p2,str(self.weight_vec[feature.index::self.features_num]))
-            print " %d\t| %s\t| %s\t| %s\t| Omitted" % (feature.index, self.getStrFeatureSet(feature.index), feature.p1, feature.p2)
+            print(" %d\t| %s\t| %s\t| %s\t| Omitted" % (feature.index, self.getStrFeatureSet(feature.index), feature.p1, feature.p2))
 
     def showPotentials(self):
-        print "Potentials:"
-        print "-" * 30
-        print " index\t| f_set\t| relevance\t| count\t| p1\t| p2"
-        print "-" * 30
-        for _, potential in self.iFDD_potentials.iteritems():
-            print " %d\t| %s\t| %0.2f\t| %d\t| %s\t| %s" % (potential.index, str(np.sort(list(potential.f_set))), potential.relevance, potential.count, potential.p1, potential.p2)
+        print("Potentials:")
+        print("-" * 30)
+        print(" index\t| f_set\t| relevance\t| count\t| p1\t| p2")
+        print("-" * 30)
+        for _, potential in self.iFDD_potentials.items():
+            print(" %d\t| %s\t| %0.2f\t| %d\t| %s\t| %s" % (potential.index, str(np.sort(list(potential.f_set))), potential.relevance, potential.count, potential.p1, potential.p2))
 
     def showCache(self):
         if self.useCache:
-            print "Cache:"
+            print("Cache:")
             if len(self.cache) == 0:
-                print 'EMPTY!'
+                print('EMPTY!')
                 return
-            print "-" * 30
-            print " initial\t| Final"
-            print "-" * 30
-            for initial, active in self.cache.iteritems():
-                print " %s\t| %s" % (str(list(initial)), active)
+            print("-" * 30)
+            print(" initial\t| Final")
+            print("-" * 30)
+            for initial, active in self.cache.items():
+                print(" %s\t| %s" % (str(list(initial)), active))
 
     def updateMaxRelevance(self, newRelevance):
         # Update a global max relevance and outputs it if it is updated
@@ -515,19 +521,19 @@ class iFDD(Representation):
 
     def getFeature(self, f_id):
         # returns a feature given a feature id
-        if f_id in self.featureIndex2feature.keys():
+        if f_id in list(self.featureIndex2feature.keys()):
             return self.featureIndex2feature[f_id]
         else:
-            print "F_id %d is not valid" % f_id
+            print("F_id %d is not valid" % f_id)
             return None
 
     def getStrFeatureSet(self, f_id):
         # returns a string that corresponds to the set of features specified by
         # the given feature_id
-        if f_id in self.featureIndex2feature.keys():
+        if f_id in list(self.featureIndex2feature.keys()):
             return str(sorted(list(self.featureIndex2feature[f_id].f_set)))
         else:
-            print "F_id %d is not valid" % f_id
+            print("F_id %d is not valid" % f_id)
             return None
 
     def featureType(self):
@@ -545,12 +551,12 @@ class iFDD(Representation):
             self.maxBatchDiscovery,
             self.batchThreshold,
             self.iFDDPlus)
-        for s, f in self.iFDD_features.items():
+        for s, f in list(self.iFDD_features.items()):
             new_f = deepcopy(f)
             new_s = deepcopy(s)
             ifdd.iFDD_features[new_s] = new_f
             ifdd.featureIndex2feature[new_f.index] = new_f
-        for s, p in self.iFDD_potentials.items():
+        for s, p in list(self.iFDD_potentials.items()):
             new_s = deepcopy(s)
             new_p = deepcopy(p)
             ifdd.iFDD_potentials[new_s] = deepcopy(new_p)
@@ -596,9 +602,9 @@ class iFDDK_potential(iFDD_potential):
             plus = self.random_state.rand() >= kappa
 
         if plus:
-            return np.abs(self.b) / np.sqrt(self.c)
+            return old_div(np.abs(self.b), np.sqrt(self.c))
         else:
-            return self.a / np.sqrt(self.c)
+            return old_div(self.a, np.sqrt(self.c))
 
     def update_statistics(self, rho, td_error, lambda_, discount_factor, phi, n_rho):
         # phi = phi_s[self.p1] * phi_s[self.p2]
@@ -663,7 +669,7 @@ def _set_comp_lt(a, b):
     l2 = list(b)
     l1.sort()
     l2.sort()
-    for i in xrange(len(l1)):
+    for i in range(len(l1)):
         if l1[i] < l2[i]:
             return -1
         if l1[i] > l2[i]:
@@ -689,8 +695,8 @@ class iFDDK(iFDD):
             self.hp_dtype = np.dtype('float128')
         except TypeError:
             self.hp_dtype = np.dtype('float64')
-    	self.y_a = defaultdict(lambda: np.array(0., dtype=self.hp_dtype))
-    	self.y_b = defaultdict(lambda: np.array(0., dtype=self.hp_dtype))
+        self.y_a = defaultdict(lambda: np.array(0., dtype=self.hp_dtype))
+        self.y_b = defaultdict(lambda: np.array(0., dtype=self.hp_dtype))
         self.lambda_ = lambda_
         self.kappa = kappa
         self.discount_factor = domain.discount_factor
@@ -706,15 +712,15 @@ class iFDDK(iFDD):
         self.t_rho[self.n_rho] = self.t
 
     def showPotentials(self):
-        print "Potentials:"
-        print "-" * 30
-        print " index\t| f_set\t| relevance\t| count\t| p1\t| p2"
-        print "-" * 30
+        print("Potentials:")
+        print("-" * 30)
+        print(" index\t| f_set\t| relevance\t| count\t| p1\t| p2")
+        print("-" * 30)
 
-        k = sorted(self.iFDD_potentials.iterkeys(), cmp=_set_comp_lt)
+        k = sorted(iter(self.iFDD_potentials.keys()), cmp=_set_comp_lt)
         for f_set in k:
             potential = self.iFDD_potentials[f_set]
-            print " %d\t| %s\t| %g\t| %d\t| %s\t| %s" % (potential.index, str(np.sort(list(potential.f_set))), potential.relevance(plus=True), potential.c, potential.p1, potential.p2)
+            print(" %d\t| %s\t| %g\t| %d\t| %s\t| %s" % (potential.index, str(np.sort(list(potential.f_set))), potential.relevance(plus=True), potential.c, potential.p1, potential.p2))
 
     def post_discover(self, s, terminal, a, td_error, phi_s, rho=1):
         """
@@ -734,7 +740,7 @@ class iFDDK(iFDD):
                 # create potential if necessary
                 dd[self.get_potential(g_index, h_index).f_set] = phi_s[g_index] * phi_s[h_index]
 
-            for f, potential in self.iFDD_potentials.items():
+            for f, potential in list(self.iFDD_potentials.items()):
                 potential.update_statistics(
                     rho, td_error, self.lambda_, self.discount_factor, dd[f], self.n_rho)
                 # print plus, potential.relevance(plus=plus)

--- a/rlpy/Representations/slow_kernels.py
+++ b/rlpy/Representations/slow_kernels.py
@@ -1,23 +1,26 @@
 """Pure python implementation of the kernels module"""
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 
 
 def gaussian_kernel(x, y, dim, sigma):
-    return np.exp(- float((((x[dim] - y[dim]) / sigma[dim]) ** 2).sum()))
+    return np.exp(- float(((old_div((x[dim] - y[dim]), sigma[dim])) ** 2).sum()))
 
 
 def truncated_gaussian_kernel(x, y, dim, sigma, threshold):
-    res = np.exp(- float((((x[dim] - y[dim]) / sigma[dim]) ** 2).sum()))
+    res = np.exp(- float(((old_div((x[dim] - y[dim]), sigma[dim])) ** 2).sum()))
     res -= threshold
     if res < 0:
         return 0.
-    res *= 1. / (1. - threshold)
+    res *= old_div(1., (1. - threshold))
     return res
 
 
 def discretization_kernel(x, y, dim, sigma):
     return (
-        np.all(np.floor(x[dim] / sigma[dim]) == np.floor(y[dim] / sigma[dim]))
+        np.all(np.floor(old_div(x[dim], sigma[dim])) == np.floor(old_div(y[dim], sigma[dim])))
     )
 
 
@@ -26,26 +29,26 @@ def linf_kernel(x, y, dim, sigma):
 
 
 def linf_triangle_kernel(x, y, dim, sigma):
-    d = 1. - (abs(x[dim] - y[dim]) / sigma[dim])
+    d = 1. - (old_div(abs(x[dim] - y[dim]), sigma[dim]))
     d[d <= 0] = 0
     return d.min()
 
 
 def all_gaussian_kernel(x, centers, widths):
-    dimv = range(len(x))
+    dimv = list(range(len(x)))
     res = np.zeros(len(centers))
 
-    for i in xrange(len(centers)):
+    for i in range(len(centers)):
         res[i] = gaussian_kernel(x, centers[i], dimv, widths[i])
     return res
 
 
 def all_linf_triangle_kernel(x, centers, widths):
 
-    dimv = range(len(x))
+    dimv = list(range(len(x)))
     res = np.zeros(len(centers))
 
-    for i in xrange(len(centers)):
+    for i in range(len(centers)):
         res[i] = linf_triangle_kernel(x, centers[i], dimv, widths[i])
     return res
 

--- a/rlpy/Representations/slow_kernels.py
+++ b/rlpy/Representations/slow_kernels.py
@@ -1,5 +1,10 @@
 """Pure python implementation of the kernels module"""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from past.utils import old_div
 import numpy as np

--- a/rlpy/Tools/GeneralTools.py
+++ b/rlpy/Tools/GeneralTools.py
@@ -1,8 +1,15 @@
 """General Tools for use throughout RLPy"""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
 
+from builtins import int
+from builtins import round
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import filter
 from builtins import zip

--- a/rlpy/Tools/GeneralTools.py
+++ b/rlpy/Tools/GeneralTools.py
@@ -1,6 +1,13 @@
 """General Tools for use throughout RLPy"""
+from __future__ import division
+from __future__ import print_function
 
 
+from builtins import str
+from builtins import filter
+from builtins import zip
+from builtins import range
+from past.utils import old_div
 def module_exists(module_name):
     try:
         __import__(module_name)
@@ -46,7 +53,7 @@ def available_matplotlib_backends():
 
     # filter all files in that directory to identify all files which provide a
     # backend
-    backend_fnames = filter(is_backend_module, os.listdir(backends_dir))
+    backend_fnames = list(filter(is_backend_module, os.listdir(backends_dir)))
 
     backends = [backend_fname_formatter(fname) for fname in backend_fnames]
     return backends
@@ -60,8 +67,8 @@ if module_exists('matplotlib'):
     if matplotlib_backend in mpl_backends:
         plt.switch_backend(matplotlib_backend)
     else:
-        print "Warning: Matplotlib backend", matplotlib_backend, "not available"
-        print "Available backends:", mpl_backends
+        print("Warning: Matplotlib backend", matplotlib_backend, "not available")
+        print("Available backends:", mpl_backends)
     from matplotlib import pylab as pl
     import matplotlib.ticker as ticker
     from matplotlib import rc, colors
@@ -74,7 +81,7 @@ if module_exists('matplotlib'):
     from matplotlib.patches import ConnectionStyle  # for cartpole
     pl.ion()
 else:
-    print 'matplotlib is not available => No Graphics'
+    print('matplotlib is not available => No Graphics')
 
 if module_exists('networkx'):
     import networkx as nx
@@ -94,7 +101,7 @@ from time import clock
 from hashlib import sha1
 import datetime
 import csv
-from string import lower
+# from string import lower
 # from Sets import ImmutableSet
 # from heapq import *
 import multiprocessing
@@ -153,11 +160,11 @@ def cartesian(arrays, out=None):
     if out is None:
         out = np.zeros([n, len(arrays)], dtype=dtype)
 
-    m = n / arrays[0].size
+    m = old_div(n, arrays[0].size)
     out[:, 0] = np.repeat(arrays[0], m)
     if arrays[1:]:
         cartesian(arrays[1:], out=out[0:m, 1:])
-        for j in xrange(1, arrays[0].size):
+        for j in range(1, arrays[0].size):
             out[j * m:(j + 1) * m, 1:] = out[0:m, 1:]
     return out
 
@@ -202,7 +209,7 @@ def count_nonzero(arr):
                 nnz += 1
         return nnz
 
-    print "In tools.py attempted count_nonzero with unsupported type of", type(arr)
+    print("In tools.py attempted count_nonzero with unsupported type of", type(arr))
     return None
 
 
@@ -268,8 +275,8 @@ def bin2state(bin, num_bins, limits):
     in the middle of the bin (ie, the average of the discretizations around it)
 
     """
-    bin_width = (limits[1] - limits[0]) / (num_bins * 1.)
-    return bin * bin_width + bin_width / 2.0 + limits[0]
+    bin_width = old_div((limits[1] - limits[0]), (num_bins * 1.))
+    return bin * bin_width + old_div(bin_width, 2.0) + limits[0]
 
 
 def state2bin(s, num_bins, limits):
@@ -296,11 +303,11 @@ def state2bin(s, num_bins, limits):
         return num_bins - 1
     width = limits[1] - limits[0]
     if s > limits[1]:
-        print 'Tools.py: WARNING: ', s, ' > ', limits[1], '. Using the chopped value of s'
-        print 'Ignoring', limits[1] - s
+        print('Tools.py: WARNING: ', s, ' > ', limits[1], '. Using the chopped value of s')
+        print('Ignoring', limits[1] - s)
         s = limits[1]
     elif s < limits[0]:
-        print 'Tools.py: WARNING: ', s, ' < ', limits[0], '. Using the chopped value of s'
+        print('Tools.py: WARNING: ', s, ' < ', limits[0], '. Using the chopped value of s')
 #        print("WARNING: %s is out of limits of %s . Using the chopped value of s" %(str(s),str(limits)))
         s = limits[0]
     return int((s - limits[0]) * num_bins / (width * 1.))
@@ -373,17 +380,17 @@ def make_colormap(colors):
 
     from matplotlib.colors import LinearSegmentedColormap, ColorConverter
 
-    z = np.sort(colors.keys())
+    z = np.sort(list(colors.keys()))
     n = len(z)
     z1 = min(z)
     zn = max(z)
-    x0 = (z - z1) / ((zn - z1) * 1.)
+    x0 = old_div((z - z1), ((zn - z1) * 1.))
 
     CC = ColorConverter()
     R = []
     G = []
     B = []
-    for i in xrange(n):
+    for i in range(n):
         # i'th color at level z[i]:
         Ci = colors[z[i]]
         if isinstance(Ci, str):
@@ -397,9 +404,9 @@ def make_colormap(colors):
         B.append(RGB[2])
 
     cmap_dict = {}
-    cmap_dict['red'] = [(x0[i], R[i], R[i]) for i in xrange(len(R))]
-    cmap_dict['green'] = [(x0[i], G[i], G[i]) for i in xrange(len(G))]
-    cmap_dict['blue'] = [(x0[i], B[i], B[i]) for i in xrange(len(B))]
+    cmap_dict['red'] = [(x0[i], R[i], R[i]) for i in range(len(R))]
+    cmap_dict['green'] = [(x0[i], G[i], G[i]) for i in range(len(G))]
+    cmap_dict['blue'] = [(x0[i], B[i], B[i]) for i in range(len(B))]
     mymap = LinearSegmentedColormap('mymap', cmap_dict)
     return mymap
 
@@ -469,7 +476,7 @@ def make_amrcolors(nlevels=4):
         linecolors = linecolors[:nlevels]
         bgcolors = bgcolors[:nlevels]
     else:
-        print "*** Warning, suggest nlevels <= 16"
+        print("*** Warning, suggest nlevels <= 16")
 
     return (linecolors, bgcolors)
 
@@ -584,7 +591,7 @@ def findRow(rowVec, X):
 
     # return nonzero(any(logical_and.reduce([X[:, i] == r[i] for i in arange(len(r))])))
     # return any(logical_and(X[:, 0] == r[0], X[:, 1] == r[1]))
-    ind = np.nonzero(np.logical_and.reduce([X[:, i] == rowVec[i] for i in xrange(len(rowVec))]))
+    ind = np.nonzero(np.logical_and.reduce([X[:, i] == rowVec[i] for i in range(len(rowVec))]))
     return ind[0]
 
 
@@ -628,7 +635,7 @@ def perms_r(X, perm_sample=np.array([]), allPerms=None, ind=0):
                 allPerms, ind = perms_r(
                     X[1:], np.hstack((perm_sample, [x])), allPerms, ind)
         else:
-            for x in xrange(X[0]):
+            for x in range(X[0]):
                 allPerms, ind = perms_r(
                     X[1:], np.hstack((perm_sample, [x])), allPerms, ind)
     return allPerms, ind
@@ -658,7 +665,7 @@ def vec2id2(x, limits):
     if isinstance(x, int):
         return x
     lim_prod = np.cumprod(limits[:-1])
-    return x[0] + sum(map(lambda x_y: x_y[0] * x_y[1], zip(x[1:], lim_prod)))
+    return x[0] + sum([x_y[0] * x_y[1] for x_y in zip(x[1:], lim_prod)])
 
 
 def vec2id(x, limits):
@@ -682,7 +689,7 @@ def vec2id(x, limits):
     if isinstance(x, int):
         return x
     _id = 0
-    for d in xrange(len(x) - 1, -1, -1):
+    for d in range(len(x) - 1, -1, -1):
         _id *= limits[d]
         _id += x[d]
 
@@ -706,7 +713,7 @@ def id2vec(_id, limits):
     """
     prods = np.cumprod(limits)
     s = [0] * len(limits)
-    for d in xrange(len(prods) - 1, 0, -1):
+    for d in range(len(prods) - 1, 0, -1):
 #       s[d] = _id / prods[d-1]
 #       _id %= prods[d-1]
         s[d], _id = divmod(_id, prods[d - 1])
@@ -778,21 +785,21 @@ def powerset(iterable, ascending=1):
     s = list(iterable)
     if ascending:
         return (
-            chain.from_iterable(combinations(s, r) for r in xrange(len(s) + 1))
+            chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
         )
     else:
         return (
             chain.from_iterable(combinations(s, r)
-                                for r in xrange(len(s) + 1, -1, -1))
+                                for r in range(len(s) + 1, -1, -1))
         )
 
 
 def printClass(obj):
     """ Print class name and all attributes of object ``obj``. """
-    print className(obj)
-    print '======================================='
-    for property, value in vars(obj).iteritems():
-        print property, ": ", value
+    print(className(obj))
+    print('=======================================')
+    for property, value in vars(obj).items():
+        print(property, ": ", value)
 
 
 def addNewElementForAllActions(weight_vec, actions_num, newElem=None):
@@ -855,11 +862,11 @@ def solveLinear(A, b):
             error = np.linalg.norm(
                 (np.dot(A, result.reshape(-1, 1)) - b.reshape(-1, 1))[0])
         else:
-            print 'Attempted to solve linear equation Ax=b in solveLinear() of Tools.py with a non-numpy (array / matrix) type.'
+            print('Attempted to solve linear equation Ax=b in solveLinear() of Tools.py with a non-numpy (array / matrix) type.')
             sys.exit(1)
 
     if error > RESEDUAL_THRESHOLD:
-        print "||Ax-b|| = %0.1f" % error
+        print("||Ax-b|| = %0.1f" % error)
     return result.ravel(), solve_time
 
 
@@ -922,7 +929,7 @@ def drawHist(data, bins=50, fig=101):
     """
     hist, bins = np.histogram(data, bins=bins)
     width = 0.7 * (bins[1] - bins[0])
-    center = (bins[:-1] + bins[1:]) / 2
+    center = old_div((bins[:-1] + bins[1:]), 2)
     plt.figure(fig)
     plt.bar(center, hist, align='center', width=width)
 
@@ -1070,14 +1077,14 @@ def regularize(A):
         # print 'REGULARIZE', type(A)
     else:
         # print 'REGULARIZE', type(A)
-        for i in xrange(x):
+        for i in range(x):
             A[i, i] += REGULARIZATION
     return A
 
 
 def sparsity(A):
     """ Returns the percentage of nonzero elements in ``A``. """
-    return (1 - np.count_nonzero(A) / (np.prod(A.shape) * 1.)) * 100
+    return (1 - old_div(np.count_nonzero(A), (np.prod(A.shape) * 1.))) * 100
 
 
 # CURRENTLY UNUSED
@@ -1090,7 +1097,7 @@ def incrementalAverageUpdate(avg, sample, sample_number):
     Updates an average incrementally.
 
     """
-    return avg + (sample - avg) / (sample_number * 1.)
+    return avg + old_div((sample - avg), (sample_number * 1.))
 
 
 def padZeros(X, L):
@@ -1210,7 +1217,7 @@ def rk4(derivs, y0, t, *args, **kwargs):
 
         thist = t[i]
         dt = t[i + 1] - thist
-        dt2 = dt / 2.0
+        dt2 = old_div(dt, 2.0)
         y0 = yout[i]
 
         k1 = np.asarray(derivs(y0, thist, *args, **kwargs))

--- a/rlpy/Tools/PriorityQueueWithNovelty.py
+++ b/rlpy/Tools/PriorityQueueWithNovelty.py
@@ -1,6 +1,11 @@
 """Priority Queue with Novelty"""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import object

--- a/rlpy/Tools/PriorityQueueWithNovelty.py
+++ b/rlpy/Tools/PriorityQueueWithNovelty.py
@@ -1,5 +1,9 @@
 """Priority Queue with Novelty"""
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from builtins import object
 from heapq import heappush, heappop
 from copy import deepcopy
 
@@ -54,7 +58,7 @@ class PriorityQueueWithNovelty(object):
         temp = list(self._h)
         for i in range(len(temp)):
             p, c, x = heappop(temp)
-            print "Priority = %d, Novelty = %d, Obj = %s" % (p, c, str(x))
+            print("Priority = %d, Novelty = %d, Obj = %s" % (p, c, str(x)))
 
     def __deepcopy__(self, memo):
         new_q = PriorityQueueWithNovelty()

--- a/rlpy/Tools/__init__.py
+++ b/rlpy/Tools/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from .GeneralTools import *
 from .PriorityQueueWithNovelty import PriorityQueueWithNovelty
 from .GeneralTools import __rlpy_location__

--- a/rlpy/Tools/condor.py
+++ b/rlpy/Tools/condor.py
@@ -1,5 +1,13 @@
 """Useful functions for interfacing with condor"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import int
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
 import subprocess
 import re
 

--- a/rlpy/Tools/gprof2dot.py
+++ b/rlpy/Tools/gprof2dot.py
@@ -18,7 +18,16 @@
 
 """Generate a dot graph from the output of several profilers."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import next
+from builtins import dict
+from builtins import open
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from builtins import map
 from builtins import str

--- a/rlpy/Tools/hypersearch.py
+++ b/rlpy/Tools/hypersearch.py
@@ -1,5 +1,10 @@
 """Functions to be used with hyperopt for doing hyper parameter optimization."""
+from __future__ import division
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import os
 import rlpy.Tools.results as tres
 import rlpy.Tools.run as rt
@@ -30,14 +35,14 @@ def _search_condor_parallel(path, space, trials_per_point, setting,
     enqueuing loop
     """
 
-    trials = CondorTrials(path=path, ids=range(1, trials_per_point + 1),
+    trials = CondorTrials(path=path, ids=list(range(1, trials_per_point + 1)),
                           setting=setting, objective=objective)
     domain = hyperopt.Domain(dummy_f, space, rseed=123)
     trial_path = os.path.join(path, "trials.pck")
     if os.path.exists(trial_path):
         with open(trial_path) as f:
             old_trials = pickle.load(f)
-        print "Loaded existing trials"
+        print("Loaded existing trials")
         if old_trials.setting == trials.setting and trials.ids == old_trials.ids:
             trials = old_trials
     n_queued = trials.count_by_state_unsynced(hyperopt.JOB_STATES)
@@ -127,13 +132,13 @@ class CondorTrials(hyperopt.Trials):
         return rval
 
     def unwrap_hyperparam(self, vals):
-        return {a: b[0] for a, b in vals.items()}
+        return {a: b[0] for a, b in list(vals.items())}
 
     def make_full_path(self, hyperparam):
         return (
             os.path.join(
                 self.path,
-                "-".join([str(v) for v in hyperparam.values()]))
+                "-".join([str(v) for v in list(hyperparam.values())]))
         )
 
     def update_trials(self, trials):
@@ -159,9 +164,9 @@ class CondorTrials(hyperopt.Trials):
                 finished_ids = rt.get_finished_ids(path=full_path)
                 if set(finished_ids).issuperset(set(self.ids)):
                     trial["state"] = hyperopt.JOB_STATE_DONE
-                    print trial["tid"], "done"
+                    print(trial["tid"], "done")
                     trial["result"] = self.get_results(full_path)
-                    print "Parameters", hyperparam
+                    print("Parameters", hyperparam)
         return count
 
     def get_results(self, path):
@@ -173,9 +178,9 @@ class CondorTrials(hyperopt.Trials):
         avg, std, n_trials = tres.avg_quantity(res, quan)
         avg *= neg
         weights = (np.arange(len(avg)) + 1) ** 2
-        loss = (avg * weights).sum() / weights.sum()
-        print time.ctime()
-        print "Loss: {:.4g}".format(loss)
+        loss = old_div((avg * weights).sum(), weights.sum())
+        print(time.ctime())
+        print("Loss: {:.4g}".format(loss))
         # use #steps/eps at the moment
         return {"loss": loss,
                 "num_trials": n_trials[-1],
@@ -244,10 +249,10 @@ def find_hyperparameters(
         # "temporary" directory to use
         full_path = os.path.join(
             path,
-            "-".join([str(v) for v in hyperparam.values()]))
+            "-".join([str(v) for v in list(hyperparam.values())]))
 
         # execute experiment
-        rt.run(setting, location=full_path, ids=range(1, trials_per_point + 1),
+        rt.run(setting, location=full_path, ids=list(range(1, trials_per_point + 1)),
                parallelization=parallelization, force_rerun=False, block=True, **hyperparam)
 
         # all jobs should be done
@@ -266,12 +271,12 @@ def find_hyperparameters(
             val = -m
             std = s[-1]
         else:
-            print "unknown objective"
+            print("unknown objective")
         weights = (np.arange(len(val)) + 1) ** 2
-        loss = (val * weights).sum() / weights.sum()
-        print time.ctime()
-        print "Parameters", hyperparam
-        print "Loss", loss
+        loss = old_div((val * weights).sum(), weights.sum())
+        print(time.ctime())
+        print("Parameters", hyperparam)
+        print("Loss", loss)
         # use #steps/eps at the moment
         return {"loss": loss,
                 "num_trials": n[-1],
@@ -279,7 +284,7 @@ def find_hyperparameters(
                 "std_last_mean": std}
 
     if parallelization == "condor_all":
-        trials = CondorTrials(path=path, ids=range(1, trials_per_point + 1),
+        trials = CondorTrials(path=path, ids=list(range(1, trials_per_point + 1)),
                               setting=setting, objective=objective)
         domain = hyperopt.Domain(dummy_f, space, rseed=123)
         rval = hyperopt.FMinIter(hyperopt.rand.suggest, domain, trials,

--- a/rlpy/Tools/hypersearch.py
+++ b/rlpy/Tools/hypersearch.py
@@ -1,7 +1,13 @@
 """Functions to be used with hyperopt for doing hyper parameter optimization."""
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import super
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/rlpy/Tools/ipshell.py
+++ b/rlpy/Tools/ipshell.py
@@ -1,5 +1,11 @@
 """ip-shell functions"""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = ["Alborz Geramifard", "Robert H. Klein", "Christoph Dann",
                "William Dabney", "Jonathan P. How"]

--- a/rlpy/Tools/results.py
+++ b/rlpy/Tools/results.py
@@ -1,5 +1,10 @@
 """Parsing, extracting statistics and plotting of experimental results."""
+from __future__ import division
 
+from builtins import zip
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 import json
@@ -99,13 +104,13 @@ def avg_quantity(results, quantity, pad=False):
     over all runs of a certain quantity.
     If pad is true, missing entries for runs with less entries are filled with the last value
     """
-    length = max([len(v[quantity]) for v in results.itervalues()])
+    length = max([len(v[quantity]) for v in results.values()])
     mean = np.zeros(length)
     std = np.zeros(length)
     num = np.zeros(length, dtype="int")
     last_values = {}
-    for i in xrange(length):
-        for k, v in results.iteritems():
+    for i in range(length):
+        for k, v in results.items():
             if len(v[quantity]) > i:
                 last_values[k] = v[quantity][i]
                 num[i] += 1
@@ -118,7 +123,7 @@ def avg_quantity(results, quantity, pad=False):
         if num[i] > 0:
             mean[i] /= num[i]
 
-        for k, v in results.iteritems():
+        for k, v in results.items():
             if len(v[quantity]) > i:
                 last_values[k] = v[quantity][i]
                 num[i] += 1
@@ -143,7 +148,7 @@ def first_close_to_final(x, y, min_rel_proximity=0.05):
     """
     min_abs_proximity = (y[-1] - y[0]) * min_rel_proximity
     final_y = y[-1]
-    for i in xrange(len(x)):
+    for i in range(len(x)):
         if abs(y[i] - final_y) < min_abs_proximity:
             return x[i]
 
@@ -155,7 +160,7 @@ def add_first_close_entries(results, new_label="95_time",
     5% of the final quantity.
     returns nothing as the results are added in place
     """
-    for v in results.itervalues():
+    for v in results.values():
         v[new_label] = first_close_to_final(x, y, min_rel_proximity)
 
 
@@ -173,8 +178,8 @@ class MultiExperimentResults(object):
         """
         self.data = {}
         if isinstance(paths, list):
-            paths = dict(zip(paths, paths))
-        for label, path in paths.iteritems():
+            paths = dict(list(zip(paths, paths)))
+        for label, path in paths.items():
             self.data[label] = load_results(path)
 
     def plot_avg_sem(
@@ -209,13 +214,13 @@ class MultiExperimentResults(object):
         min_ = np.inf
         max_ = - np.inf
         fig = plt.figure()
-        for label, results in self.data.items():
+        for label, results in list(self.data.items()):
             style["color"] = colors[label]
             style["marker"] = markers[label]
             y_mean, y_std, y_num = avg_quantity(results, y, pad_y)
-            y_sem = y_std / np.sqrt(y_num)
+            y_sem = old_div(y_std, np.sqrt(y_num))
             x_mean, x_std, x_num = avg_quantity(results, x, pad_x)
-            x_sem = x_std / np.sqrt(x_num)
+            x_sem = old_div(x_std, np.sqrt(x_num))
 
             if xbars:
                 plt.errorbar(x_mean, y_mean, xerr=x_sem, label=label,

--- a/rlpy/Tools/results.py
+++ b/rlpy/Tools/results.py
@@ -1,6 +1,13 @@
 """Parsing, extracting statistics and plotting of experimental results."""
 from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import open
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from builtins import range
 from builtins import object

--- a/rlpy/Tools/run.py
+++ b/rlpy/Tools/run.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import joblib
 import os
 import glob
@@ -135,7 +136,7 @@ def prepare_directory(setting, path, **hyperparam):
     """
     # create file to execute
     variables = "hyper_param = dict(" + ",\n".join(["{}={}".format(k, repr(v))
-                                                    for k, v in hyperparam.items()]) + ")"
+                                                    for k, v in list(hyperparam.items())]) + ")"
     final_path = path
     if not os.path.exists(final_path):
         os.makedirs(final_path)
@@ -230,7 +231,7 @@ def run_condor(fn, ids,
                 if job["run_id"] in ids:
                     ids.remove(job["run_id"])
                     if verbose:
-                        print "Jobs #{} already submitted".format(job["run_id"])
+                        print("Jobs #{} already submitted".format(job["run_id"]))
     if len(ids) > 0:
         # write submit file
         with open(os.path.join(outdir, "submit"), "w") as f:
@@ -241,10 +242,10 @@ def run_condor(fn, ids,
         exit_code = os.system(
             "cd {dir} && condor_submit condor/submit".format(dir=dir))
         if verbose:
-            print "Jobs submitted with exit code", exit_code
+            print("Jobs submitted with exit code", exit_code)
     else:
         if verbose:
-            print "All jobs have been already submitted"
+            print("All jobs have been already submitted")
     # if blocking mode in enabled, wait until all result files are there
     # WARNING: this does not recognize killed or dead jobs and would wait
     #          infinitely long
@@ -254,6 +255,6 @@ def run_condor(fn, ids,
             finished_ids = set(get_finished_ids(dir))
             finished_ids &= set(ids)
             if verbose > 100:
-                print len(finished_ids), "of", len(ids), "jobs finished"
+                print(len(finished_ids), "of", len(ids), "jobs finished")
             if len(finished_ids) == len(ids):
                 return

--- a/rlpy/Tools/run.py
+++ b/rlpy/Tools/run.py
@@ -1,4 +1,11 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 import joblib
 import os
 import glob

--- a/rlpy/Tools/transformations.py
+++ b/rlpy/Tools/transformations.py
@@ -188,6 +188,7 @@ True
 
 from __future__ import division, print_function
 
+from builtins import object
 import math
 
 import numpy
@@ -1672,7 +1673,7 @@ _AXES2TUPLE = {
     'rzxy': (1, 1, 0, 1), 'ryxy': (1, 1, 1, 1), 'ryxz': (2, 0, 0, 1),
     'rzxz': (2, 0, 1, 1), 'rxyz': (2, 1, 0, 1), 'rzyz': (2, 1, 1, 1)}
 
-_TUPLE2AXES = dict((v, k) for k, v in _AXES2TUPLE.items())
+_TUPLE2AXES = dict((v, k) for k, v in list(_AXES2TUPLE.items()))
 
 
 def vector_norm(data, axis=None, out=None):

--- a/rlpy/Tools/transformations.py
+++ b/rlpy/Tools/transformations.py
@@ -187,7 +187,12 @@ True
 """
 
 from __future__ import division, print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
 
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
 from builtins import object
 import math
 

--- a/rlpy/__init__.py
+++ b/rlpy/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 import rlpy.Agents
 import rlpy.Tools
 import rlpy.Domains

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ Large parts of this file were taken from the pandas project
 BSD license.
 """
 import sys
+import glob
 import multiprocessing
 try:
     from setuptools import setup, Command, find_packages
@@ -238,8 +239,17 @@ setup(name="rlpy",
       zip_safe=False,
       cmdclass=cmdclass,
       long_description=open('README.rst').read(),
-      packages=find_packages(exclude=['tests', 'tests.*']),
       include_package_data=True,
+      data_files=[
+          ('rlpy/Domains/GridWorldMaps', glob.glob('./rlpy/Domains/GridWorldMaps/*.txt')),
+          ('rlpy/Domains/IntruderMonitoringMaps', glob.glob('./rlpy/Domains/IntruderMonitoringMaps/*.txt')),
+          ('rlpy/Domains/SystemAdministratorMaps', glob.glob('./rlpy/Domains/SystemAdministratorMaps/*.txt')),
+          ('rlpy/Domains/PinballConfigs', glob.glob('./rlpy/Domains/PinballConfigs/*.cfg')),
+          ('rlpy/Domains/PacmanPackage/layouts', glob.glob('./rlpy/Domains/PacmanPackage/layouts/*.lay')),
+          ('rlpy/Policies', glob.glob('./rlpy/Policies/*.mat'))
+      ],
+
+      packages=find_packages(exclude=['tests', 'tests.*']),
       install_requires=[
           'numpy >= 1.7',
           'scipy',
@@ -248,7 +258,8 @@ setup(name="rlpy",
           'scikit-learn',
           'joblib',
           'hyperopt',
-          'pymongo'
+          'pymongo',
+          'cairocffi'
       ],
       setup_requires=['numpy >= 1.7'],
       ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,6 @@ Large parts of this file were taken from the pandas project
 (https://github.com/pydata/pandas) which have been permitted for use under the
 BSD license.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import open
-from future import standard_library
-standard_library.install_aliases()
 import sys
 import glob
 import multiprocessing
@@ -266,7 +259,8 @@ setup(name="rlpy",
           'joblib',
           'hyperopt',
           'pymongo',
-          'cairocffi'
+          'cairocffi',
+          'future'
       ],
       setup_requires=['numpy >= 1.7'],
       ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,13 @@ Large parts of this file were taken from the pandas project
 (https://github.com/pydata/pandas) which have been permitted for use under the
 BSD license.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import glob
 import multiprocessing

--- a/tests/gibbs_policy.py
+++ b/tests/gibbs_policy.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import range
 from rlpy.Domains import GridWorld
 from rlpy.Representations import Tabular
 from scipy.optimize import check_grad, approx_fprime
@@ -34,5 +36,5 @@ def test_fdcheck_dlogpi():
             # print "df", df(theta, s, a)
             # print "df_approx", df_approx(theta, s, a)
             error = check_grad(f, df, theta, s, a)
-            print error
+            print(error)
             assert np.abs(error) < 1e-6

--- a/tests/gibbs_policy.py
+++ b/tests/gibbs_policy.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Domains import GridWorld
 from rlpy.Representations import Tabular

--- a/tests/test_agents/test_tdcagents.py
+++ b/tests/test_agents/test_tdcagents.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Representations.Representation import Representation
 import numpy as np

--- a/tests/test_agents/test_tdcagents.py
+++ b/tests/test_agents/test_tdcagents.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import range
 from rlpy.Representations.Representation import Representation
 import numpy as np
 import logging
@@ -49,7 +51,7 @@ def test_sarsa_valfun_chain():
     rep = MockRepresentation()
     pol = eGreedy(rep)
     agent = SARSA(pol, rep, 0.9, lambda_=0.)
-    for i in xrange(1000):
+    for i in range(1000):
         if i % 4 == 3:
             continue
         agent.learn(np.array([i % 4]), [0], 0, 1., np.array([(i + 1) % 4]), [0, ], 0, (i + 2) % 4 == 0)
@@ -65,7 +67,7 @@ def test_sarsalambda_valfun_chain():
     rep = MockRepresentation()
     pol = eGreedy(rep)
     agent = SARSA(pol, rep, 0.9, lambda_=0.5)
-    for i in xrange(1000):
+    for i in range(1000):
         if i % 4 == 3:
             agent.episodeTerminated()
             continue
@@ -82,7 +84,7 @@ def test_qlearn_valfun_chain():
     rep = MockRepresentation()
     pol = eGreedy(rep)
     agent = Q_Learning(pol, rep, 0.9, lambda_=0.)
-    for i in xrange(1000):
+    for i in range(1000):
         if i % 4 == 3:
             continue
         agent.learn(np.array([i % 4]), [0], 0, 1., np.array([(i + 1) % 4]), [0], 0, (i + 2) % 4 == 0)
@@ -98,7 +100,7 @@ def test_qlambda_valfun_chain():
     rep = MockRepresentation()
     pol = eGreedy(rep)
     agent = Q_Learning(pol, rep, 0.9, lambda_=0.5)
-    for i in xrange(1000):
+    for i in range(1000):
         if i % 4 == 3:
             agent.episodeTerminated()
             continue
@@ -115,7 +117,7 @@ def test_ggq_valfun_chain():
     rep = MockRepresentation()
     pol = eGreedy(rep)
     agent = Greedy_GQ(pol, rep, lambda_=0., discount_factor=0.9)
-    for i in xrange(1000):
+    for i in range(1000):
         if i % 4 == 3:
             agent.episodeTerminated()
             continue

--- a/tests/test_cartpole.py
+++ b/tests/test_cartpole.py
@@ -30,8 +30,8 @@ def test_cartpole():
 
 
 def check_traj(domain_class, filename):
-    with open(filename) as f:
-        traj = pickle.load(f)
+    with open(filename, 'rb') as f:
+        traj = pickle.load(f, encoding='latin1')
     traj_now = sample_random_trajectory(domain_class)
     for i, e1, e2 in zip(list(range(len(traj_now))), traj_now, traj):
         print(i)
@@ -48,7 +48,7 @@ def check_traj(domain_class, filename):
 
 def save_trajectory(domain_class, filename):
     traj = sample_random_trajectory(domain_class)
-    with open(filename, "w") as f:
+    with open(filename, 'wb') as f:
         pickle.dump(traj, f)
 
 

--- a/tests/test_cartpole.py
+++ b/tests/test_cartpole.py
@@ -1,4 +1,10 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
 from builtins import zip
 from builtins import range
 import numpy as np

--- a/tests/test_cartpole.py
+++ b/tests/test_cartpole.py
@@ -12,6 +12,7 @@ import pickle
 from nose.tools import eq_
 from rlpy.Tools import __rlpy_location__
 import os
+import sys
 
 
 def test_cartpole():
@@ -37,7 +38,10 @@ def test_cartpole():
 
 def check_traj(domain_class, filename):
     with open(filename, 'rb') as f:
-        traj = pickle.load(f, encoding='latin1')
+        if not sys.version_info[:2] == (2, 7):
+            traj = pickle.load(f, encoding='latin1')
+        else:
+            traj = pickle.load(f)
     traj_now = sample_random_trajectory(domain_class)
     for i, e1, e2 in zip(list(range(len(traj_now))), traj_now, traj):
         print(i)

--- a/tests/test_cartpole.py
+++ b/tests/test_cartpole.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from builtins import zip
+from builtins import range
 import numpy as np
 import pickle
 from nose.tools import eq_
@@ -9,7 +12,7 @@ def test_cartpole():
     try:
         from rlpy.Domains import InfCartPoleBalance
     except ImportError:
-        print "use old Cartpole class!"
+        print("use old Cartpole class!")
         from rlpy.Domains import Pendulum_InvertedBalance as InfCartPoleBalance
 
     yield check_traj, InfCartPoleBalance, os.path.join(
@@ -18,7 +21,7 @@ def test_cartpole():
     try:
         from rlpy.Domains import FiniteCartPoleBalanceOriginal
     except ImportError:
-        print "use old Cartpole class!"
+        print("use old Cartpole class!")
         from rlpy.Domains import CartPoleBalanceOriginal as FiniteCartPoleBalanceOriginal
 
     yield check_traj, FiniteCartPoleBalanceOriginal, os.path.join(
@@ -30,14 +33,14 @@ def check_traj(domain_class, filename):
     with open(filename) as f:
         traj = pickle.load(f)
     traj_now = sample_random_trajectory(domain_class)
-    for i, e1, e2 in zip(range(len(traj_now)), traj_now, traj):
-        print i
-        print e1[0], e2[0]
+    for i, e1, e2 in zip(list(range(len(traj_now))), traj_now, traj):
+        print(i)
+        print(e1[0], e2[0])
         if not np.allclose(e1[0], e2[0]):  # states
-            print e1[0], e2[0]
+            print(e1[0], e2[0])
             assert False
         eq_(e1[-1], e2[-1])  # reward
-        print "Terminal", e1[1], e2[1]
+        print("Terminal", e1[1], e2[1])
         eq_(e1[1], e2[1])  # terminal
         eq_(len(e1[2]), len(e2[2]))
         assert np.all([a == b for a, b in zip(e1[2], e2[2])])  # p_actions

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,6 +1,5 @@
 """Nosetests for testing the use cases contained in the cases directory."""
 from __future__ import print_function
-from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,6 +1,11 @@
 """Nosetests for testing the use cases contained in the cases directory."""
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import numpy as np
 from nose.tools import ok_, eq_
 import glob

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,4 +1,5 @@
 """Nosetests for testing the use cases contained in the cases directory."""
+from __future__ import print_function
 
 import numpy as np
 from nose.tools import ok_, eq_
@@ -24,7 +25,7 @@ def test_all_100_step():
 def check_running(filename, steps):
     content = read_setting_content(filename)
     local = {}
-    exec content in local
+    exec(content, local)
     make_experiment = local["make_experiment"]
     exp = make_experiment(exp_id=1, path="./Results/Temp/nosetests")
     exp.max_steps = steps
@@ -37,10 +38,10 @@ def check_running(filename, steps):
 def test_tutorial():
     content = read_setting_content("examples/tutorial/gridworld.py")
     local = {}
-    exec content in local
+    exec(content, local)
     make_experiment = local["make_experiment"]
     exp = make_experiment(exp_id=1, path="./Results/Temp/nosetests")
     exp.config_logging = False
     exp.run()
-    print "Final Return", exp.result["return"][-1]
+    print("Final Return", exp.result["return"][-1])
     assert exp.result["return"][-1] > 0.4

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,5 +1,11 @@
 """Nosetests for testing the domains and their methods."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
 import rlpy.Domains
 from rlpy.Domains.Domain import Domain
 import numpy as np

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -13,7 +13,7 @@ __license__ = "BSD 3-Clause"
 
 
 def test_random_trajectory():
-    for d in rlpy.Domains.__dict__.values():
+    for d in list(rlpy.Domains.__dict__.values()):
         if d == Domain:
             continue
         if inspect.isclass(d) and issubclass(d, Domain):
@@ -21,7 +21,7 @@ def test_random_trajectory():
 
 
 def test_specification():
-    for d in rlpy.Domains.__dict__.values():
+    for d in list(rlpy.Domains.__dict__.values()):
         if d == Domain:
             continue
         if inspect.isclass(d) and issubclass(d, Domain):

--- a/tests/test_domains/helpers.py
+++ b/tests/test_domains/helpers.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Tools import plt
 import numpy as np
 

--- a/tests/test_domains/helpers.py
+++ b/tests/test_domains/helpers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from rlpy.Tools import plt
 import numpy as np
 
@@ -6,21 +7,21 @@ def _checkSameExperimentResults(exp1, exp2):
     """ Returns False if experiments gave same results, true if they match. """
     if not np.all(exp1.result["learning_steps"] == exp2.result["learning_steps"]):
         # Same number of steps before failure (where applicable)
-        print 'LEARNING STEPS DIFFERENT'
-        print exp1.result["learning_steps"]
-        print exp2.result["learning_steps"]
+        print('LEARNING STEPS DIFFERENT')
+        print(exp1.result["learning_steps"])
+        print(exp2.result["learning_steps"])
         return False
     if not np.all(exp1.result["return"] == exp2.result["return"]):
         # Same return on each test episode
-        print 'RETURN DIFFERENT'
-        print exp1.result["return"]
-        print exp2.result["return"]
+        print('RETURN DIFFERENT')
+        print(exp1.result["return"])
+        print(exp2.result["return"])
         return False
     if not np.all(exp1.result["steps"] == exp2.result["steps"]):
         # Same number of steps taken on each training episode
-        print 'STEPS DIFFERENT'
-        print exp1.result["steps"]
-        print exp2.result["steps"]
+        print('STEPS DIFFERENT')
+        print(exp1.result["steps"])
+        print(exp2.result["steps"])
         return False
     return True
 

--- a/tests/test_domains/test_ChainMDP.py
+++ b/tests/test_domains/test_ChainMDP.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import Tabular
 from rlpy.Domains import ChainMDP
 from rlpy.Agents.TDControlAgent import SARSA

--- a/tests/test_domains/test_FiftyChain.py
+++ b/tests/test_domains/test_FiftyChain.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import Tabular
 from rlpy.Domains import FiftyChain
 from rlpy.Agents.TDControlAgent import SARSA

--- a/tests/test_domains/test_FiniteTrackCartPole.py
+++ b/tests/test_domains/test_FiniteTrackCartPole.py
@@ -1,3 +1,9 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import IncrementalTabular
 from rlpy.Domains.FiniteTrackCartPole import FiniteTrackCartPole, \
 FiniteCartPoleBalance, FiniteCartPoleSwingUp, FiniteCartPoleBalanceModern

--- a/tests/test_domains/test_InfiniteTrackCartPole.py
+++ b/tests/test_domains/test_InfiniteTrackCartPole.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from rlpy.Representations import Tabular
 from rlpy.Domains.InfiniteTrackCartPole import InfTrackCartPole, InfCartPoleBalance, InfCartPoleSwingUp
 from rlpy.Agents.TDControlAgent import SARSA
@@ -39,21 +40,21 @@ def _checkSameExperimentResults(exp1, exp2):
     """ Returns False if experiments gave same results, true if they match. """
     if not np.all(exp1.result["learning_steps"] == exp2.result["learning_steps"]):
         # Same number of steps before failure (where applicable)
-        print 'LEARNING STEPS DIFFERENT'
-        print exp1.result["learning_steps"]
-        print exp2.result["learning_steps"]
+        print('LEARNING STEPS DIFFERENT')
+        print(exp1.result["learning_steps"])
+        print(exp2.result["learning_steps"])
         return False
     if not np.all(exp1.result["return"] == exp2.result["return"]):
         # Same return on each test episode
-        print 'RETURN DIFFERENT'
-        print exp1.result["return"]
-        print exp2.result["return"]
+        print('RETURN DIFFERENT')
+        print(exp1.result["return"])
+        print(exp2.result["return"])
         return False
     if not np.all(exp1.result["steps"] == exp2.result["steps"]):
         # Same number of steps taken on each training episode
-        print 'STEPS DIFFERENT'
-        print exp1.result["steps"]
-        print exp2.result["steps"]
+        print('STEPS DIFFERENT')
+        print(exp1.result["steps"])
+        print(exp2.result["steps"])
         return False
     return True
 

--- a/tests/test_domains/test_InfiniteTrackCartPole.py
+++ b/tests/test_domains/test_InfiniteTrackCartPole.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import Tabular
 from rlpy.Domains.InfiniteTrackCartPole import InfTrackCartPole, InfCartPoleBalance, InfCartPoleSwingUp
 from rlpy.Agents.TDControlAgent import SARSA

--- a/tests/test_domains/test_PST.py
+++ b/tests/test_domains/test_PST.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import IncrementalTabular
 from rlpy.Domains import PST
 from rlpy.Domains.PST import UAVLocation, ActuatorState, SensorState, UAVAction

--- a/tests/test_domains/test_SystemAdministrator.py
+++ b/tests/test_domains/test_SystemAdministrator.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 from rlpy.Representations import IncrementalTabular
 from rlpy.Domains import SystemAdministrator

--- a/tests/test_domains/test_SystemAdministrator.py
+++ b/tests/test_domains/test_SystemAdministrator.py
@@ -1,3 +1,4 @@
+from builtins import range
 from rlpy.Representations import IncrementalTabular
 from rlpy.Domains import SystemAdministrator
 from rlpy.Agents.TDControlAgent import SARSA
@@ -86,7 +87,7 @@ def test_transitions():
     up = domain.RUNNING # shorthand
     down = domain.BROKEN # shorthand
 
-    state = np.array([up for dummy in xrange(0, domain.state_space_dims)])
+    state = np.array([up for dummy in range(0, domain.state_space_dims)])
     domain.state = state.copy()
     a = 5 # =n on this 5-machine map, ie no action
     ns = state.copy()

--- a/tests/test_representations/test_BEBF.py
+++ b/tests/test_representations/test_BEBF.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import BEBF
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np

--- a/tests/test_representations/test_Fourier.py
+++ b/tests/test_representations/test_Fourier.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import Fourier
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 from rlpy.Agents.TDControlAgent import TDControlAgent, SARSA

--- a/tests/test_representations/test_IncrementalTabular.py
+++ b/tests/test_representations/test_IncrementalTabular.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import IncrementalTabular
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np

--- a/tests/test_representations/test_IndependentDiscretization.py
+++ b/tests/test_representations/test_IndependentDiscretization.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import IndependentDiscretization
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np

--- a/tests/test_representations/test_IndependentDiscretizationCompactBinary.py
+++ b/tests/test_representations/test_IndependentDiscretizationCompactBinary.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import IndependentDiscretizationCompactBinary
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole, SystemAdministrator
 import numpy as np

--- a/tests/test_representations/test_LocalBases.py
+++ b/tests/test_representations/test_LocalBases.py
@@ -1,5 +1,9 @@
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from past.utils import old_div
 from rlpy.Representations.LocalBases import NonparametricLocalBases, RandomLocalBases
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole

--- a/tests/test_representations/test_LocalBases.py
+++ b/tests/test_representations/test_LocalBases.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
 from rlpy.Representations.LocalBases import NonparametricLocalBases, RandomLocalBases
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np
@@ -8,7 +11,7 @@ try:
     from rlpy.Representations.kernels import *
 except ImportError:
     from rlpy.Representations.slow_kernels import *
-    print "C-Extensions for kernels not available, expect slow runtime"
+    print("C-Extensions for kernels not available, expect slow runtime")
 
 def test_parametric_rep():
     """
@@ -36,8 +39,8 @@ def test_parametric_rep():
 
         # width lies within resolution bounds
         statespace_range = domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]
-        assert np.all(statespace_range / resolution_max <= rep.widths[0]) # widths[0] has `state_space_dims` cols
-        assert np.all(rep.widths[0] <= statespace_range / resolution_min)
+        assert np.all(old_div(statespace_range, resolution_max) <= rep.widths[0]) # widths[0] has `state_space_dims` cols
+        assert np.all(rep.widths[0] <= old_div(statespace_range, resolution_min))
 
         phiVecOrigin = rep.phi(np.array([0,0], dtype=np.float), terminal=False)
         assert np.all(phiVecOrigin >= 0) # nonnegative feat func values
@@ -115,7 +118,7 @@ def test_nonparametric_rep():
         assert np.all(rep.centers[0,:] == origS)
         assert np.all(rep.centers[1,:] == s2)
         statespace_range = domain.statespace_limits[:, 1] - domain.statespace_limits[:, 0]
-        assert np.all(rep.widths == statespace_range / resolution)
+        assert np.all(rep.widths == old_div(statespace_range, resolution))
 
         phiVecOrigin = rep.phi(np.array([0,0], dtype=np.float), terminal=False)
         assert np.all(phiVecOrigin >= 0) # nonnegative feat func values

--- a/tests/test_representations/test_OMPTD.py
+++ b/tests/test_representations/test_OMPTD.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import OMPTD, IndependentDiscretization
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np

--- a/tests/test_representations/test_Tabular.py
+++ b/tests/test_representations/test_Tabular.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import Tabular
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np

--- a/tests/test_representations/test_TileCoding.py
+++ b/tests/test_representations/test_TileCoding.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from rlpy.Representations import TileCoding
 from rlpy.Domains import GridWorld, InfiniteTrackCartPole
 import numpy as np

--- a/tests/test_representations/test_iFDD.py
+++ b/tests/test_representations/test_iFDD.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from builtins import str
+from builtins import range
 from rlpy.Representations import iFDD
 from rlpy.Representations import IndependentDiscretizationCompactBinary
 import rlpy.Domains
@@ -18,56 +21,56 @@ def deterministic_test():
     rep = iFDD(domain, discovery_threshold, initialRep,
                debug=0, useCache=1, sparsify=sparsify)
     rep.theta = np.arange(rep.features_num * domain.actions_num) * 10
-    print 'Initial [0,1] => ',
+    print('Initial [0,1] => ', end=' ')
     ANSWER = np.sort(rep.findFinalActiveFeatures([0, 1]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([0, 1]))
     # rep.show()
 
-    print rep.inspectPair(0, 1, discovery_threshold + 1)
+    print(rep.inspectPair(0, 1, discovery_threshold + 1))
     # rep.show()
     ANSWER = np.sort(rep.findFinalActiveFeatures([0, 1]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([21]))
 
-    print 'Initial [2,3] => ',
+    print('Initial [2,3] => ', end=' ')
     ANSWER = np.sort(rep.findFinalActiveFeatures([2, 3]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([2, 3]))
     # rep.showCache()
     # rep.showFeatures()
     # rep.showCache()
-    print 'Initial [0,20] => ',
+    print('Initial [0,20] => ', end=' ')
     ANSWER = np.sort(rep.findFinalActiveFeatures([0, 20]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([0, 20]))
 
-    print 'Initial [0,1,20] => ',
+    print('Initial [0,1,20] => ', end=' ')
     ANSWER = np.sort(rep.findFinalActiveFeatures([0, 1, 20]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([20, 21]))
     rep.showCache()
     # Change the weight for new feature 40
     rep.theta[40] = -100
-    print 'Initial [0,20] => ',
+    print('Initial [0,20] => ', end=' ')
     ANSWER = np.sort(rep.findFinalActiveFeatures([0, 20]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([0, 20]))
 
-    print 'discover 0,1,20'
+    print('discover 0,1,20')
     rep.inspectPair(20, rep.features_num - 1, discovery_threshold + 1)
     # rep.showFeatures()
     # rep.showCache()
-    print 'Initial [0,1,20] => ',
+    print('Initial [0,1,20] => ', end=' ')
     ANSWER = np.sort(rep.findFinalActiveFeatures([0, 1, 20]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([22]))
 
     rep.showCache()
-    print 'Initial [0,1,2,3,4,5,6,7,8,20] => ',
+    print('Initial [0,1,2,3,4,5,6,7,8,20] => ', end=' ')
     ANSWER = np.sort(
         rep.findFinalActiveFeatures([0, 1, 2, 3, 4, 5, 6, 7, 8, 20]))
-    print ANSWER
+    print(ANSWER)
     assert np.array_equal(ANSWER, np.array([2, 3, 4, 5, 6, 7, 8, 22]))
     # rep.showCache()
 
@@ -91,12 +94,12 @@ def random_test():
         iFDDPlus=0)
     rep.theta = np.arange(rep.features_num * domain.actions_num) * 10
     n = rep.features_num
-    for i in xrange(TRIALS):
+    for i in range(TRIALS):
         phi = np.zeros(n, 'bool')
-        for j in xrange(K):
+        for j in range(K):
             ind = np.random.randint(0, n - 1)
             phi[ind] = 1
             threshold = np.random.rand() * 2 - 1
-        print '%d: %0.2f >> %s' % (i + 1, threshold, str(phi.nonzero()[0]))
+        print('%d: %0.2f >> %s' % (i + 1, threshold, str(phi.nonzero()[0])))
         rep.discover(phi, threshold)
     rep.show()

--- a/tests/test_representations/test_iFDD.py
+++ b/tests/test_representations/test_iFDD.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from rlpy.Representations import iFDD


### PR DESCRIPTION
Adding support for Python 3 using the python [future](http://python-future.org) library.
Changes a result of running `futurize` + some manual fixes (esp. for setuptools installing static assets).
All tests pass with python 3.6.
Also fixes #25